### PR TITLE
kcqrs: pluggable message format

### DIFF
--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineKcqrs.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineKcqrs.kt
@@ -1,6 +1,7 @@
 package com.clouway.kcqrs.adapter.appengine
 
 import com.clouway.kcqrs.core.*
+import com.clouway.kcqrs.core.messages.MessageFormatFactory
 
 /**
  * AppEngineKcqrs is an AppEngine implementation of Kcqrs which uses the GAE datastore for persistence of events
@@ -11,9 +12,9 @@ import com.clouway.kcqrs.core.*
  *
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-class AppEngineKcqrs(eventKind: String = "Event", eventHandlerEndpoint: String) : Kcqrs {
+class AppEngineKcqrs(eventKind: String = "Event", eventHandlerEndpoint: String, messageFormatFactory: MessageFormatFactory) : Kcqrs {
     private val messageBus = SimpleMessageBus()
-    private val eventStore = AppEngineEventStore(eventKind)
+    private val eventStore = AppEngineEventStore(eventKind, messageFormatFactory.createMessageFormat())
     private val eventPublisher = TaskQueueEventPublisher(eventHandlerEndpoint)
     private val repository = EventRepository(eventStore, eventPublisher)
 

--- a/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/AppEngineEventStoreTest.kt
+++ b/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/AppEngineEventStoreTest.kt
@@ -21,6 +21,8 @@ class AppEngineEventStoreTest {
     private val helper = LocalServiceTestHelper(LocalDatastoreServiceTestConfig()
             .setDefaultHighRepJobPolicyUnappliedJobPercentage(100f))
 
+    private val eventStore = AppEngineEventStore(messageFormat = TestingJsonFormat())
+
     @Before
     fun setUp() {
         helper.setUp()
@@ -31,9 +33,9 @@ class AppEngineEventStoreTest {
         helper.tearDown()
     }
 
+
     @Test
     fun getEventsThatAreStored() {
-        val eventStore = AppEngineEventStore()
         val aggregateId = UUID.randomUUID()
 
         val aggregate = User(aggregateId, "John")
@@ -47,7 +49,6 @@ class AppEngineEventStoreTest {
 
     @Test
     fun detectEventCollisions() {
-        val eventStore = AppEngineEventStore()
         val aggregateId = UUID.randomUUID()
 
         val aggregate = User(aggregateId, "John")
@@ -64,7 +65,6 @@ class AppEngineEventStoreTest {
 
     @Test
     fun multipleEvents() {
-        val eventStore = AppEngineEventStore()
         val aggregateId = UUID.randomUUID()
 
         val user = User(aggregateId, "John")
@@ -82,7 +82,6 @@ class AppEngineEventStoreTest {
     
     @Test
     fun multipleEventsAfterGet() {
-        val eventStore = AppEngineEventStore()
         val aggregateId = UUID.randomUUID()
 
         var user = User(aggregateId, "John")

--- a/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/TestingJsonFormat.kt
+++ b/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/TestingJsonFormat.kt
@@ -1,0 +1,23 @@
+package com.clouway.kcqrs.adapter.appengine
+
+import com.clouway.kcqrs.core.messages.MessageFormat
+import com.google.gson.Gson
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.lang.reflect.Type
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class TestingJsonFormat : MessageFormat {
+    private val gson = Gson()
+
+    override fun <T> parse(stream: InputStream, type: Type): T {
+        return gson.fromJson(InputStreamReader(stream, Charsets.UTF_8), type)
+    }
+
+    override fun format(value: Any): String {
+        return gson.toJson(value)
+    }
+
+}

--- a/kcqrs-client-gson/build.gradle
+++ b/kcqrs-client-gson/build.gradle
@@ -1,0 +1,50 @@
+group 'com.clouway.kcqrs'
+
+description = 'kcqrs-core'
+
+buildscript {
+  ext.kotlin_version = '1.2.30'
+
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
+}
+
+apply plugin: 'java'
+apply plugin: 'kotlin'
+
+repositories {
+  mavenCentral()
+}
+
+configurations {
+  providedCompile
+}
+
+dependencies {
+  compile project(':kcqrs-core')
+  compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+  compile 'com.google.code.gson:gson:2.8.0'
+  
+  testCompile group: 'junit', name: 'junit', version: '4.12'
+
+}
+
+sourceSets.main.compileClasspath += configurations.providedCompile
+sourceSets.test.compileClasspath += configurations.providedCompile
+sourceSets.test.runtimeClasspath += configurations.providedCompile
+
+javadoc {
+  failOnError = false
+  classpath = configurations.compile + configurations.providedCompile
+}
+
+compileKotlin {
+  kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+  kotlinOptions.jvmTarget = "1.8"
+}

--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormat.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormat.kt
@@ -1,0 +1,23 @@
+package com.clouway.kcqrs.client.gson
+
+import com.clouway.kcqrs.core.messages.MessageFormat
+import com.google.gson.Gson
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.lang.reflect.Type
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+internal class GsonMessageFormat : MessageFormat {
+    private val gson = Gson()
+
+    override fun <T> parse(stream: InputStream, type: Type): T {
+        return gson.fromJson<T>(InputStreamReader(stream, Charsets.UTF_8), type)
+    }
+
+    override fun format(value: Any): String {
+        return gson.toJson(value)
+    }
+
+}

--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormatFactory.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormatFactory.kt
@@ -1,0 +1,15 @@
+package com.clouway.kcqrs.client.gson
+
+import com.clouway.kcqrs.core.messages.MessageFormat
+import com.clouway.kcqrs.core.messages.MessageFormatFactory
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class GsonMessageFormatFactory : MessageFormatFactory {
+
+    override fun createMessageFormat(): MessageFormat {
+        return GsonMessageFormat()
+    }
+
+}

--- a/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/gson/FormatMessagesUsingGsonTest.kt
+++ b/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/gson/FormatMessagesUsingGsonTest.kt
@@ -1,0 +1,25 @@
+package com.clouway.kcqrs.client.gson
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.core.IsEqual.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+import java.io.ByteArrayInputStream
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class FormatMessagesUsingGsonTest {
+
+    @Test
+    fun parseFormattedMessage() {
+        val messageFormat  = GsonMessageFormatFactory().createMessageFormat()
+        val msg = messageFormat.format(User("Emilia Clark", "Daenerys Targaryen"))
+
+        val user = messageFormat.parse<User>(ByteArrayInputStream(msg.toByteArray(Charsets.UTF_8)), User::class.java)
+        assertThat(user.name, `is`(equalTo("Emilia Clark")))
+        assertThat(user.nickname, `is`(equalTo("Daenerys Targaryen")))
+    }
+}
+
+data class User(@JvmField val name: String, @JvmField val nickname: String)

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/messages/MessageFormat.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/messages/MessageFormat.kt
@@ -1,0 +1,22 @@
+package com.clouway.kcqrs.core.messages
+
+import java.io.InputStream
+import java.lang.reflect.Type
+
+/**
+ * JsonFormat is an abstract JSON message format used for parsing and serializing of input messages.
+ * 
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+interface MessageFormat {
+
+    /**
+     * Parses JSON content from the provided input stream.
+     */
+    fun <T> parse(stream: InputStream, type: Type): T
+    
+    /**
+     * Formats the provided value into a JSON object
+     */
+    fun format(value: Any): String
+}

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/messages/MessageFormatFactory.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/messages/MessageFormatFactory.kt
@@ -1,0 +1,14 @@
+package com.clouway.kcqrs.core.messages
+
+/**
+ * JsonFactory is an factory class which
+ * 
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+interface MessageFormatFactory {
+    /**
+     * Creates a new MessageFormat. 
+     */
+    fun createMessageFormat(): MessageFormat
+
+}

--- a/kcqrs-example/build.gradle
+++ b/kcqrs-example/build.gradle
@@ -30,6 +30,7 @@ repositories {
 
 dependencies {
   compile project(':kcqrs-appengine')
+  compile project(':kcqrs-client-gson')
   compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 
   providedCompile "com.google.appengine:appengine:$gae_version"

--- a/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/CQRSContext.kt
+++ b/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/CQRSContext.kt
@@ -3,6 +3,7 @@ package com.clouway.kcqrs.example
 
 
 import com.clouway.kcqrs.adapter.appengine.AppEngineKcqrs
+import com.clouway.kcqrs.client.gson.GsonMessageFormatFactory
 import com.clouway.kcqrs.core.MessageBus
 import com.clouway.kcqrs.core.Repository
 
@@ -10,7 +11,7 @@ import com.clouway.kcqrs.core.Repository
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 object CQRSContext {
-    private var cqrs = AppEngineKcqrs("Event", "/worker/kcqrs")
+    private var cqrs = AppEngineKcqrs("Event", "/worker/kcqrs", GsonMessageFormatFactory())
 
     fun messageBus() : MessageBus {
         return cqrs.messageBus()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'kcqrs'
 include 'kcqrs-core',
+        'kcqrs-client-gson',
         'kcqrs-appengine',
         'kcqrs-testing',
         'kcqrs-example'


### PR DESCRIPTION
Added pluggable message format instead of direct gson usages. This makes code pluggable and client code will be able to hook it's own message format depending on the needs.

kcqrs-client-gson was introduced as side effect of this change to provide an implementation of message format which uses Gson.