### PR TITLE
kcqrs-client: add aggregate type to save events request

### DIFF
--- a/kcqrs-client/src/main/kotlin/com/clouway/kcqrs/client/HttpEventStore.kt
+++ b/kcqrs-client/src/main/kotlin/com/clouway/kcqrs/client/HttpEventStore.kt
@@ -27,7 +27,7 @@ class HttpEventStore(private val endpoint: URL,
         try {
             val request = requestFactory.buildPostRequest(
                     GenericUrl(endpoint.toString() + "/v1/aggregates"),
-                    JsonHttpContent(GsonFactory.getDefaultInstance(), SaveEventsRequestDto(aggregateId, saveOptions.version, saveOptions.topicName, requestEvents))
+                    JsonHttpContent(GsonFactory.getDefaultInstance(), SaveEventsRequestDto(aggregateId, aggregateType, saveOptions.version, saveOptions.topicName, requestEvents))
             )
             request.throwExceptionOnExecuteError = false
 
@@ -113,9 +113,9 @@ internal data class EventPayloadDto(@Key @JvmField var kind: String, @Key @JvmFi
     constructor() : this("", 0L, "", "")
 }
 
-internal data class SaveEventsRequestDto(@Key @JvmField var aggregateId: String, @Key @JvmField var version: Long, @Key @JvmField var topicName: String, @Key @JvmField var events: List<EventPayloadDto>) : GenericJson() {
+internal data class SaveEventsRequestDto(@Key @JvmField var aggregateId: String, @Key @JvmField var aggregateType: String, @Key @JvmField var version: Long, @Key @JvmField var topicName: String, @Key @JvmField var events: List<EventPayloadDto>) : GenericJson() {
     @Suppress("UNUSED")
-    constructor() : this("", 0L, "", mutableListOf())
+    constructor() : this("", "", 0L, "", mutableListOf())
 }
 
 internal data class SaveEventsResponseDto(@Key @JvmField var aggregateId: String, @Key @JvmField var version: Long) : GenericJson() {

--- a/kcqrs-client/src/test/kotlin/HttpEventStoreTest.kt
+++ b/kcqrs-client/src/test/kotlin/HttpEventStoreTest.kt
@@ -65,13 +65,13 @@ class HttpEventStoreTest {
             it.parser = GsonFactory.getDefaultInstance().createJsonObjectParser()
         })
 
-        store.saveEvents(aggregateId, listOf(EventPayload("::kind::", 1L, "::user::", Binary("::event data::"))), SaveOptions(aggregateId, 1L, "crm"))
+        store.saveEvents("Invoice", listOf(EventPayload("::kind::", 1L, "::user::", Binary("::event data::"))), SaveOptions(aggregateId, 1L, "crm"))
 
         val outputStream = ByteArrayOutputStream()
         transport.lowLevelHttpRequest.streamingContent.writeTo(outputStream)
 
         assertThat(outputStream.toString(), `is`(equalTo(
-                """{"aggregateId":"$aggregateId","events":[{"identityId":"::user::","kind":"::kind::","payload":"::event data::","timestamp":1}],"topicName":"crm","version":1}""".trimIndent()
+                """{"aggregateId":"$aggregateId","aggregateType":"Invoice","events":[{"identityId":"::user::","kind":"::kind::","payload":"::event data::","timestamp":1}],"topicName":"crm","version":1}""".trimIndent()
         )))
     }
 


### PR DESCRIPTION
Now aggregate type is passed correctly to persistence layer.