### PR TITLE
kcqrs-client: pass security token using custom initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ private var cqrs = AppEngineKcqrs.Builder(configuration, messageFormatFactory).b
     kind = "Event"
     kcqrsHandlerEndpoint = "/worker/kcqrs"
     identityProvider = IdentityProvider.Default()
+    requestInitializer = HttpRequestInitializer { 
+        it.headers.setAuthorization("Bearer ${securityProvider.getAuthorizationToken()}")
+    }
 } 
 
 // Accessing message bus

--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonHttpKCQRSClient.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonHttpKCQRSClient.kt
@@ -3,6 +3,7 @@ package com.clouway.kcqrs.client.gson
 import com.clouway.kcqrs.client.HttpEventStore
 import com.clouway.kcqrs.client.SyncEventPublisher
 import com.clouway.kcqrs.core.*
+import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.client.http.HttpTransport
 import com.google.api.client.json.gson.GsonFactory
 import java.net.URL
@@ -36,6 +37,7 @@ class GsonHttpKCQRSClient(private val messageBus: MessageBus,
 
         var identityProvider: IdentityProvider = IdentityProvider.Default()
         var eventPublisher: EventPublisher = SyncEventPublisher(messageBus)
+        var requestInitializer: HttpRequestInitializer = NopHttpRequestInitializer()
 
         fun build(init: Builder.() -> Unit): Kcqrs {
             init()
@@ -44,6 +46,7 @@ class GsonHttpKCQRSClient(private val messageBus: MessageBus,
                     endpoint,
                     transport.createRequestFactory { request ->
                         request.parser = GsonFactory.getDefaultInstance().createJsonObjectParser()
+                        requestInitializer.initialize(request)
                     }
             )
 

--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/NopHttpRequestInitializer.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/NopHttpRequestInitializer.kt
@@ -1,0 +1,17 @@
+package com.clouway.kcqrs.client.gson
+
+import com.google.api.client.http.HttpRequest
+import com.google.api.client.http.HttpRequestInitializer
+
+/**
+ * NopHttpRequestInitializer is an initializer which is doing nothing and is used when
+ * client code doesn't have concrete one set.
+ * 
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+internal class NopHttpRequestInitializer : HttpRequestInitializer {
+    override fun initialize(request: HttpRequest) {
+        // nop
+    }
+
+}


### PR DESCRIPTION
Code which is using the GsonHttpKCQRSClient is now able to add additional attributes to the request which are send to the target server using the hooked GsonHttpKCQRSClient.

This interceptor is use-full when security tokens need to be passed to the target backend.