### PR TITLE
kcqrs-core: handle AggregateNotFound response

### DIFF
--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
@@ -80,6 +80,9 @@ class SimpleAggregateRepository(private val eventStore: EventStore,
                 return aggregate
 
             }
+            is GetEventsResponse.AggregateNotFound -> {
+                throw AggregateNotFoundException(id)
+            }
             else -> throw IllegalStateException("unknown state")
         }
     }

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
@@ -121,6 +121,13 @@ class SimpleAggregateRepositoryTest {
         }
     }
 
+    @Test(expected = AggregateNotFoundException::class)
+    fun aggregateNotFound() {
+        val eventPublisher = InMemoryEventPublisher()
+        val eventRepository = SimpleAggregateRepository(InMemoryEventStore(), TestMessageFormat(), eventPublisher, configuration)
+        eventRepository.getById(invoiceId(), Invoice::class.java)
+    }
+
     private fun invoiceId() = UUID.randomUUID().toString()
 
     data class InvoiceCreatedEvent(@JvmField val invoiceId: String, @JvmField val customerName: String) : Event


### PR DESCRIPTION
Now is thrown exception "AggregateNotFound" when event store return
response "GetEventsResponse.AggregateNotFound"