### PR TITLE
kcqrs-testing: add testing capabilities to InMemoryMessageBus

### DIFF
--- a/kcqrs-testing/build.gradle
+++ b/kcqrs-testing/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 
   compile 'com.google.code.gson:gson:2.8.0'
   compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+
+  testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
 compileKotlin {

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBus.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBus.kt
@@ -5,10 +5,12 @@ import com.clouway.kcqrs.core.*
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-class InMemoryMessageBus : MessageBus {
+class InMemoryMessageBus() : MessageBus {
+    val handledEvents = mutableListOf<EventWithPayload>()
+    val sentCommands = mutableListOf<Command>()
     
     override fun handle(event: EventWithPayload) {
-
+        handledEvents.add(event)
     }
 
     override fun <T : Command> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T>) {
@@ -20,7 +22,7 @@ class InMemoryMessageBus : MessageBus {
     }
 
     override fun <T : Command> send(command: T) {
-
+        sentCommands.add(command)
     }
 
     override fun registerInterceptor(interceptor: Interceptor) {

--- a/kcqrs-testing/src/test/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBusTest.kt
+++ b/kcqrs-testing/src/test/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBusTest.kt
@@ -1,0 +1,34 @@
+package com.clouway.kcqrs.testing
+
+import com.clouway.kcqrs.core.Command
+import com.clouway.kcqrs.core.Event
+import com.clouway.kcqrs.core.EventWithPayload
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class InMemoryMessageBusTest {
+
+    @Test
+    fun handleCommands() {
+        val messageBus = InMemoryMessageBus()
+        val command = DummyCommand()
+        messageBus.send(command)
+
+        assertThat(messageBus.sentCommands[0], `is`(equalTo(command as Command)))
+    }
+
+    @Test
+    fun handleEvents() {
+        val messageBus = InMemoryMessageBus()
+        messageBus.handle(EventWithPayload(DummyEvent(), "::payload::"))
+        assertThat(messageBus.handledEvents[0].payload, `is`(equalTo("::payload::")))
+    }
+
+    class DummyCommand : Command
+    class DummyEvent : Event
+}


### PR DESCRIPTION
Client code is now able to assert Commands and Events using the testing helper InMemoryMessageBus.