### PR TITLE
kcqrs-client: clean up duplicated MessageBus

### DIFF
--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonHttpKCQRSClient.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonHttpKCQRSClient.kt
@@ -33,8 +33,8 @@ class GsonHttpKCQRSClient(private val messageBus: MessageBus,
     class Builder(private val configuration: Configuration,
                   private val endpoint: URL,
                   private val transport: HttpTransport) {
-        val messageBus: MessageBus = SimpleMessageBus()
 
+        val messageBus = SimpleMessageBus()
         var identityProvider: IdentityProvider = IdentityProvider.Default()
         var eventPublisher: EventPublisher = SyncEventPublisher(messageBus)
         var requestInitializer: HttpRequestInitializer = NopHttpRequestInitializer()
@@ -49,8 +49,7 @@ class GsonHttpKCQRSClient(private val messageBus: MessageBus,
                         requestInitializer.initialize(request)
                     }
             )
-
-            val messageBus = SimpleMessageBus()
+            
             val messageFormat = GsonMessageFormatFactory().createMessageFormat()
 
             val aggregateRepository = SimpleAggregateRepository(eventStore, messageFormat, eventPublisher, configuration)


### PR DESCRIPTION
GsonHttpKCQRSClient was using 2 instances of MessageBus which seems wrong and this change is removed the one of them.