### PR TITLE
kcqrs-client-gson: add type adapters for LocalDate and LocalDateTime

### DIFF
--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormat.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormat.kt
@@ -1,18 +1,21 @@
 package com.clouway.kcqrs.client.gson
 
 import com.clouway.kcqrs.core.messages.MessageFormat
-import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import java.io.InputStream
 import java.io.InputStreamReader
-import java.io.OutputStream
-import java.io.OutputStreamWriter
 import java.lang.reflect.Type
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 internal class GsonMessageFormat : MessageFormat {
-    private val gson = Gson()
+    private val gson = GsonBuilder()
+            .registerTypeAdapter(LocalDate::class.java, ISOLocalDateAdapter())
+            .registerTypeAdapter(LocalDateTime::class.java, ISOLocalDateTimeAdapter())
+            .create()
 
     override fun <T> parse(stream: InputStream, type: Type): T {
         return gson.fromJson<T>(InputStreamReader(stream, Charsets.UTF_8), type)

--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/ISOLocalDateAdapter.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/ISOLocalDateAdapter.kt
@@ -1,0 +1,21 @@
+package com.clouway.kcqrs.client.gson
+
+import com.google.gson.*
+import java.lang.reflect.Type
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+internal class ISOLocalDateAdapter : JsonSerializer<LocalDate>, JsonDeserializer<LocalDate> {
+
+  override fun serialize(src: LocalDate?, typeOfSrc: Type, context: JsonSerializationContext): JsonElement? {
+    val dateFormatAsString = DateTimeFormatter.ISO_LOCAL_DATE.format(src)
+    return JsonPrimitive(dateFormatAsString)
+  }
+
+  override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext?): LocalDate? {
+    return DateTimeFormatter.ISO_LOCAL_DATE.parse(json.asString, LocalDate::from)
+  }
+}

--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/ISOLocalDateTimeAdapter.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/ISOLocalDateTimeAdapter.kt
@@ -1,0 +1,21 @@
+package com.clouway.kcqrs.client.gson
+
+import com.google.gson.*
+import java.lang.reflect.Type
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+internal class ISOLocalDateTimeAdapter : JsonSerializer<LocalDateTime>, JsonDeserializer<LocalDateTime> {
+
+    override fun serialize(src: LocalDateTime?, type: Type, context: JsonSerializationContext): JsonElement? {
+        val dateFormatAsString = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(src)
+        return JsonPrimitive(dateFormatAsString)
+    }
+
+    override fun deserialize(json: JsonElement, type: Type, context: JsonDeserializationContext?): LocalDateTime? {
+        return DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse(json.asString, LocalDateTime::from)
+    }
+}

--- a/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/gson/FormatMessagesUsingGsonTest.kt
+++ b/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/gson/FormatMessagesUsingGsonTest.kt
@@ -1,25 +1,87 @@
 package com.clouway.kcqrs.client.gson
 
 import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.core.IsEqual.equalTo
 import org.junit.Assert.assertThat
 import org.junit.Test
 import java.io.ByteArrayInputStream
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 class FormatMessagesUsingGsonTest {
+    val messageFormat = GsonMessageFormatFactory().createMessageFormat()
 
     @Test
     fun parseFormattedMessage() {
-        val messageFormat  = GsonMessageFormatFactory().createMessageFormat()
+
         val msg = messageFormat.format(User("Emilia Clark", "Daenerys Targaryen"))
 
         val user = messageFormat.parse<User>(ByteArrayInputStream(msg.toByteArray(Charsets.UTF_8)), User::class.java)
         assertThat(user.name, `is`(equalTo("Emilia Clark")))
         assertThat(user.nickname, `is`(equalTo("Daenerys Targaryen")))
     }
+
+
+    @Test
+    fun encodesLocalDateTimeInISO8601Format() {
+        val jsonPayload = messageFormat.format(DummyLocalDateTime(LocalDateTime.of(2018, 4, 15, 12, 3, 4)))
+        val nullPayload = messageFormat.format(DummyLocalDateTime(null))
+        assertThat(jsonPayload, `is`(equalTo("""{"issuedOn":"2018-04-15T12:03:04"}""")))
+        assertThat(nullPayload, `is`(equalTo("{}")))
+    }
+
+    @Test
+    fun decodeLocalDateTimeFromISO8601Format() {
+        val content = messageFormat.parse<DummyLocalDateTime>(
+                ByteArrayInputStream("""{"issuedOn":"2018-04-15T11:04:05"}""".toByteArray(Charsets.UTF_8)),
+                DummyLocalDateTime::class.java
+        )
+
+        assertThat(content, `is`(equalTo(DummyLocalDateTime(LocalDateTime.of(2018, 4, 15, 11, 4, 5)))))
+    }
+    
+    @Test
+    fun using24HourFormat() {
+        val jsonPayload = messageFormat.format(DummyLocalDateTime(LocalDateTime.of(2018, 4, 15, 16, 3, 4)))
+        assertThat(jsonPayload, `is`(equalTo("""{"issuedOn":"2018-04-15T16:03:04"}""")))
+    }
+
+    @Test
+    fun decodeNullLocalDateTime() {
+        val content = messageFormat.parse<DummyLocalDateTime>(
+                ByteArrayInputStream("""{"issuedOn":null}""".toByteArray(Charsets.UTF_8)),
+                DummyLocalDateTime::class.java
+        )
+
+        assertThat(content.issuedOn, `is`(nullValue()))
+    }
+
+    @Test
+    fun encodeLocalDateInISO8601Format() {
+        val jsonPayload = messageFormat.format(DummyLocalDate(LocalDate.of(2018, 4, 15)))
+        val nullPayload = messageFormat.format(DummyLocalDate(null))
+        assertThat(jsonPayload, `is`(equalTo("""{"issuedOn":"2018-04-15"}""")))
+        assertThat(nullPayload, `is`(equalTo("{}")))
+    }
+
+    @Test
+    fun decodeLocalDateFromISO8601Format() {
+        val content = messageFormat.parse<DummyLocalDate>(
+                ByteArrayInputStream("""{"issuedOn":"2018-06-23"}""".toByteArray(Charsets.UTF_8)),
+                DummyLocalDate::class.java
+        )
+
+        assertThat(content, `is`(equalTo(DummyLocalDate(LocalDate.of(2018, 6, 23)))))
+    }
+
 }
 
-data class User(@JvmField val name: String, @JvmField val nickname: String)
+internal data class DummyLocalDateTime(val issuedOn: LocalDateTime?)
+
+internal data class DummyLocalDate(val issuedOn: LocalDate?)
+
+internal data class User(@JvmField val name: String, @JvmField val nickname: String)


### PR DESCRIPTION
Added type adapters for LocalDate and LocalDateTime types which may be commonly used by client code.