### PR TITLE
kcqrs-core: rename identifier of AggregateRootBase

### DIFF
--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRoot.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRoot.kt
@@ -8,9 +8,9 @@ package com.clouway.kcqrs.core
  */
 interface AggregateRoot {
     /**
-     * get the Id
+     * Gets the ID of the aggregate
      *
-     * @return
+     * @return the ID of the aggregate
      */
     fun getId(): String?
 

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRootBase.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRootBase.kt
@@ -10,7 +10,7 @@ import java.util.*
  *
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-abstract class AggregateRootBase private constructor(@JvmField protected var uuid: String?) : AggregateRoot {
+abstract class AggregateRootBase private constructor(@JvmField protected var aggregateId: String?) : AggregateRoot {
 
   private var changes: ArrayList<Event> = ArrayList()
   private var version = 0L
@@ -18,7 +18,7 @@ abstract class AggregateRootBase private constructor(@JvmField protected var uui
   constructor() : this(null)
 
   override fun getId(): String? {
-    return uuid
+    return aggregateId
   }
 
   override fun markChangesAsCommitted() {

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
@@ -163,7 +163,7 @@ class SimpleAggregateRepositoryTest {
         }
 
         fun apply(event: InvoiceCreatedEvent) {
-            uuid = event.invoiceId
+            aggregateId = event.invoiceId
             customerName = event.customerName
         }
 

--- a/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/domain/Product.kt
+++ b/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/domain/Product.kt
@@ -20,7 +20,7 @@ class Product(@JvmField var name: String) : AggregateRootBase() {
     }
 
     fun apply(event: ProductRegisteredEvent) {
-        this.uuid = event.id
+        this.aggregateId = event.id
         this.name = event.name
     }
 

--- a/kcqrs-testing/src/test/kotlin/com/clouway/kcqrs/testing/InMemoryAggregateRepositoryTest.kt
+++ b/kcqrs-testing/src/test/kotlin/com/clouway/kcqrs/testing/InMemoryAggregateRepositoryTest.kt
@@ -55,7 +55,7 @@ internal class Order private constructor(var customerName: String) : AggregateRo
     }
 
     fun apply(event: OrderCreatedEvent) {
-        uuid = event.id
+        aggregateId = event.id
         customerName = event.customerName
     }
 


### PR DESCRIPTION
The identifier of AggregateRootBase is now named aggregateId instead of uuid which was concrete and may enforce UUID usages all over the place.