### PR TITLE
kcqrs: bulk loading of aggregates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=v0.0.3-SNAPSHOT
+version=v0.0.4-SNAPSHOT

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
@@ -27,6 +27,14 @@ interface EventStore {
     fun getEvents(aggregateId: String): GetEventsResponse
 
     /**
+     * Retrieves the events that are saved for the stored aggregates.
+     *
+     * @param aggregateIds a list of IDs of the aggregates which events should be retrieved
+     * @return a response of events for each of the requested aggregates
+     */
+    fun getEvents(aggregateIds: List<String>): GetEventsResponse
+
+    /**
      * Reverts last events that are stored for the aggregate.
      */
     fun revertLastEvents(aggregateId: String, count: Int): RevertEventsResponse
@@ -68,7 +76,7 @@ sealed class SaveEventsResponse {
 
 sealed class GetEventsResponse {
 
-    data class Success(val aggregateId: String, val aggregateType: String, val snapshot: Snapshot?, val version: Long, val events: List<EventPayload>) : GetEventsResponse()
+    data class Success(val aggregates: List<Aggregate>) : GetEventsResponse()
 
     object SnapshotNotFound : GetEventsResponse()
 
@@ -94,6 +102,7 @@ sealed class RevertEventsResponse {
     data class Error(val message: String) : RevertEventsResponse()
 }
 
+data class Aggregate(val aggregateId: String, val aggregateType: String, val snapshot: Snapshot?, val version: Long, val events: List<EventPayload>)
 
 data class Snapshot(private val version: Long, private val data: Binary)
 

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
@@ -39,7 +39,7 @@ class SimpleAggregateRepository(private val eventStore: EventStore,
                     throw ex
                 }
             }
-            is SaveEventsResponse.EventCollision ->{
+            is SaveEventsResponse.EventCollision -> {
                 throw EventCollisionException(aggregate.getId()!!, response.expectedVersion)
             }
             else -> throw IllegalStateException("unable to save events")
@@ -59,11 +59,14 @@ class SimpleAggregateRepository(private val eventStore: EventStore,
                 adapter.fetchMetadata(type)
 
                 val history = mutableListOf<Event>()
-                response.events.forEach {
-                    val eventType = Class.forName(adapter.eventType(it.kind))
 
-                    val event = messageFormat.parse<Event>(ByteArrayInputStream(it.data.payload), eventType)
-                    history.add(event)
+                response.aggregates.forEach {
+                    it.events.forEach {
+                        val eventType = Class.forName(adapter.eventType(it.kind))
+
+                        val event = messageFormat.parse<Event>(ByteArrayInputStream(it.data.payload), eventType)
+                        history.add(event)
+                    }
                 }
 
                 /*

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
@@ -102,7 +102,7 @@ class SimpleAggregateRepositoryTest {
             fail("exception wasn't re-thrown when publishing failed?")
         } catch (ex: PublishErrorException) {
             val response = eventStore.getEvents(invoice.getId()!!) as GetEventsResponse.Success
-            assertThat(response.events.isEmpty(), `is`(true))
+            assertThat(response.aggregates[0].events.isEmpty(), `is`(true))
         }
     }
 
@@ -128,7 +128,7 @@ class SimpleAggregateRepositoryTest {
             fail("exception wasn't re-thrown when publishing failed?")
         } catch (ex: PublishErrorException) {
             val response = eventStore.getEvents(invoice.getId()!!) as GetEventsResponse.Success
-            assertThat(response.events.size, `is`(1))
+            assertThat(response.aggregates[0].events.size, `is`(1))
         }
     }
 

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryEventStore.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryEventStore.kt
@@ -31,9 +31,30 @@ class InMemoryEventStore : EventStore {
         if (!idToAggregate.containsKey(aggregateId)) {
             return GetEventsResponse.AggregateNotFound
         }
+
         val aggregate = idToAggregate[aggregateId]!!
 
-        return GetEventsResponse.Success(aggregateId, aggregate.aggregateType, null, aggregate.events.size.toLong(), aggregate.events)
+        return GetEventsResponse.Success(listOf(Aggregate(
+                aggregateId,
+                aggregate.aggregateType,
+                null,
+                aggregate.events.size.toLong(),
+                aggregate.events)
+        ))
+    }
+
+    override fun getEvents(aggregateIds: List<String>): GetEventsResponse {
+        val aggregates = aggregateIds.map {
+            val aggregate = idToAggregate[it]!!
+            Aggregate(
+                    it,
+                    aggregate.aggregateType,
+                    null,
+                    aggregate.events.size.toLong(),
+                    aggregate.events
+            )
+        }
+        return GetEventsResponse.Success(aggregates)
     }
 
     override fun revertLastEvents(aggregateId: String, count: Int): RevertEventsResponse {


### PR DESCRIPTION
Added bulk loading of aggregates which is going to improve performance when a list of aggregates need to be loaded with a single request.

Fixes #23