### PR TITLE
kcqrs: bulk loading in AggregateRepository

### DIFF
--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AuditAwareAggregateRepository.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AuditAwareAggregateRepository.kt
@@ -27,4 +27,14 @@ interface AuditAwareAggregateRepository {
     @Throws(HydrationException::class, AggregateNotFoundException::class)
     fun <T : AggregateRoot> getById(id: String, type: Class<T>): T
 
+    /**
+     * Get a set of aggregates by providing a list of ids.
+     *
+     * @param ids the list of ID's
+     * @return a list of aggregates or empty list if none of them is matching
+     * @throws HydrationException
+     */
+    @Throws(HydrationException::class, AggregateNotFoundException::class)
+    fun <T : AggregateRoot> getByIds(ids: List<String>, type: Class<T>): Map<String, T>
+
 }

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryEventStore.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryEventStore.kt
@@ -44,7 +44,7 @@ class InMemoryEventStore : EventStore {
     }
 
     override fun getEvents(aggregateIds: List<String>): GetEventsResponse {
-        val aggregates = aggregateIds.map {
+        val aggregates = aggregateIds.filter { idToAggregate.containsKey(it) }.map {
             val aggregate = idToAggregate[it]!!
             Aggregate(
                     it,


### PR DESCRIPTION
Added bulk loading method in the AuditAwareAggregateRepository for loading of bulk aggregates from the event store.

```kotlin
// Retrives Order Aggregates with ID 1,2 and 3.
val orders = aggregateRepository.getByIds(listOf("1", "2", "3"), Order::class.java)
```