### PR TITLE
kcqrs-core: command validation during sending

### DIFF
--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/CommonValidators.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/CommonValidators.kt
@@ -1,0 +1,48 @@
+package com.clouway.kcqrs.core
+
+private val emailRegex = kotlin.text.Regex("^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$")
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+val anEmailAddress = object : Validator<String> {
+    override fun validate(fieldValue: String): Boolean {
+        return fieldValue.matches(emailRegex)
+    }
+}
+
+fun <T> equal(expected: T?): Validator<T?> {
+    return object : Validator<T?> {
+        override fun validate(fieldValue: T?): Boolean {
+            return expected == fieldValue
+        }
+    }
+}
+
+fun <T> notEqualTo(expected: T?): Validator<T?> {
+    return object : Validator<T?> {
+        override fun validate(fieldValue: T?): Boolean {
+            return expected != fieldValue
+        }
+    }
+}
+
+fun <T : Comparable<T>> greatherThan(expected: T): Validator<T> {
+    return object : Validator<T> {
+        override fun validate(fieldValue: T): Boolean {
+            return fieldValue > expected
+        }
+    }
+}
+
+fun <T : Comparable<T>> lowerThan(expected: T): Validator<T> {
+    return object : Validator<T> {
+        override fun validate(fieldValue: T): Boolean {
+            return fieldValue < expected
+        }
+    }
+}
+
+infix fun <T> T.shouldBe(validator: Validator<T>): Boolean {
+    return validator.validate(this)
+}

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/MessageBus.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/MessageBus.kt
@@ -15,7 +15,7 @@ interface MessageBus {
      * @param aClass
      * @param handler
      */
-    fun <T : Command> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T>)
+    fun <T : Command> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T>, validation: Validation<T> = Validation {})
 
     /**
      * Register an event handler

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/Validation.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/Validation.kt
@@ -1,0 +1,54 @@
+package com.clouway.kcqrs.core
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class Validation<in T>(private val validations: Map<String, ChildValidation<T>>) {
+
+    companion object {
+        operator fun <T> invoke(init: ValidationBuilder<T>.() -> Unit): Validation<T> {
+            val builder = ValidationBuilder<T>()
+            return builder.apply(init).build()
+        }
+    }
+
+    fun validate(value: T): Map<String, List<String>> {
+        val messages = mutableMapOf<String, List<String>>()
+        validations.forEach { map ->
+            val errors = map.value.validations.filter { !it.first.invoke(value) }.map { it.second }.takeIf { it.isNotEmpty() }
+            errors?.also {
+                messages[map.key] = it
+            }
+        }
+        return messages
+    }
+
+}
+
+class ValidationBuilder<T> {
+    var childValidations: MutableMap<String, ChildValidation<T>> = mutableMapOf()
+
+    operator fun String.invoke(init: ChildValidation<T>.() -> Unit) {
+        childValidations[this] = ChildValidation<T>().apply(init)
+    }
+
+    fun build(): Validation<T> {
+        return Validation(childValidations)
+    }
+
+}
+
+class ChildValidation<T> {
+    var validations: MutableList<Pair<T.() -> Boolean, String>> = mutableListOf()
+
+    fun be(validate: T.() -> Boolean) = validate
+
+    infix fun (T.() -> Boolean).not(error: String) {
+        validations.add(this to error)
+    }
+
+}
+
+interface Validator<in T> {
+    fun validate(fieldValue: T): Boolean
+}

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/ViolationErrorException.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/ViolationErrorException.kt
@@ -1,0 +1,8 @@
+package com.clouway.kcqrs.core
+
+/**
+ * ValidationErrorException is an exceptional class which is thrown when validation cannot be performed.
+ *
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class ViolationErrorException(val errors: Map<String, List<String>>) : RuntimeException()

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/CommonValidatorsTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/CommonValidatorsTest.kt
@@ -1,0 +1,32 @@
+package com.clouway.kcqrs.core
+
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class CommonValidatorsTest {
+    
+    @Test
+    fun emailValidation() {
+        val cases = listOf(
+                Case("m@m.com", true),
+                Case("m.m@test.com", true),
+                Case("m.m@t.com", true),
+                Case("m@.co", false),
+                Case("m@", false),
+                Case("mk12()*@gmail.com", false),
+                Case("m", false)
+        )
+
+        cases.forEach {
+            val valid = anEmailAddress.validate(it.email)
+            if (valid != it.expected) {
+                fail("expected validation of ${it.email} to be ${it.expected} but was $valid")
+            }
+        }
+    }
+}
+
+internal data class Case(val email: String, val expected: Boolean)

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/ValidationTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/ValidationTest.kt
@@ -1,0 +1,78 @@
+package com.clouway.kcqrs.core
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.core.IsEqual.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+import java.time.LocalDateTime
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class ValidationTest {
+
+    @Test
+    fun happyPath() {
+        val confirmUserValidator = Validation<ConfirmUserCommand> {
+            "email" {
+                be { email shouldBe anEmailAddress } not "email: in format yourname@yourmail.com"
+            }
+
+            "amount" {
+                be { amount > 0.0 } not "amount: greather then zero"
+            }
+        }
+
+        val command = ConfirmUserCommand("user11", "testtest.com", 0.0, LocalDateTime.now())
+        val errors = confirmUserValidator.validate(command)
+
+        assertThat(errors, `is`(equalTo(
+                mapOf(
+                        "email" to listOf("email: in format yourname@yourmail.com"),
+                        "amount" to listOf("amount: greather then zero")
+                )
+        )))
+    }
+
+    @Test
+    fun usingCustomValidator() {
+        val anyInstantTime = LocalDateTime.now()
+
+        val confirmUserValidation = Validation<ConfirmUserCommand> {
+            "createdOn" {
+                be {
+                    createOn shouldBe notEqualTo(anyInstantTime)
+                } not "createdOn: must be specified"
+            }
+        }
+
+        val command = ConfirmUserCommand("user11", "test", 0.0, anyInstantTime)
+        val errors = confirmUserValidation.validate(command)
+
+        assertThat(errors, `is`(equalTo(
+                mapOf(
+                        "createdOn" to listOf("createdOn: must be specified")
+                )
+        )))
+    }
+
+    @Test
+    fun allValidationsArePassing() {
+        val confirmUserValidator = Validation<ConfirmUserCommand> {
+            "email" {
+                be { email shouldBe anEmailAddress } not "email: in format yourname@yourmail.com"
+            }
+
+            "amount" {
+                be { amount > 0.0 } not "amount: greather then zero"
+            }
+        }
+
+        val command = ConfirmUserCommand("user11", "yourname@yourmail.com", 5.0, LocalDateTime.now())
+        val errors = confirmUserValidator.validate(command)
+
+        assertThat(errors, `is`(equalTo(mapOf())))
+    }
+}
+
+data class ConfirmUserCommand(val userId: String, val email: String, val amount: Double, val createOn: LocalDateTime)

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBus.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBus.kt
@@ -13,7 +13,7 @@ class InMemoryMessageBus() : MessageBus {
         handledEvents.add(event)
     }
 
-    override fun <T : Command> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T>) {
+    override fun <T : Command> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T>, validation: Validation<T>) {
 
     }
 


### PR DESCRIPTION
Added Command validation in the SimpleMessageBus which is performed before command is send to the specified handler.

The added validation is declarative and this is a sample of DDL for such:
```kotlin
 val confirmUserValidator = Validation<ConfirmUserCommand> {
	 "email" {
		 be { email shouldBe anEmailAddress } not "email: in format yourname@yourmail.com"
	 }

	 "amount" {
		 be { amount > 0.0 } not "amount: greather then zero"
	 }
}
```

Fixes #6