### PR TITLE
kcqrs-core: not save aggregate without events

### DIFF
--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
@@ -22,6 +22,8 @@ class SimpleAggregateRepository(private val eventStore: EventStore,
             EventPayload(it.event::class.java.simpleName, identity.time.toEpochMilli(), identity.id, Binary(it.payload))
         }
 
+        if(events.isEmpty()) return
+
         val response = eventStore.saveEvents(
                 aggregate::class.java.simpleName,
                 events,

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
@@ -11,7 +11,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import java.time.LocalDateTime
 import java.time.ZoneOffset
-import java.util.*
+import java.util.UUID
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
@@ -34,6 +34,18 @@ class SimpleAggregateRepositoryTest {
 
         val loadedInvoice = eventRepository.getById(invoice.getId()!!, Invoice::class.java)
         assertThat(loadedInvoice.customerName, equalTo("John"))
+    }
+
+    @Test(expected = AggregateNotFoundException::class)
+    fun notSaveAggregateWithoutEvents() {
+        val eventRepository = SimpleAggregateRepository(InMemoryEventStore(), TestMessageFormat(), InMemoryEventPublisher(), configuration)
+
+        val invoice = Invoice(invoiceId(), "John")
+        invoice.markChangesAsCommitted()
+
+        eventRepository.save(invoice, anyIdentity)
+
+        eventRepository.getById(invoice.getId()!!, Invoice::class.java)
     }
 
     @Test


### PR DESCRIPTION
If aggregate contains logic which call method "applyChanges(.)" after some checks then is possible current aggregate to not have changes for saving. In this case is not necessary calling "EventStore".