### PR TITLE
kcqrs: implement AuthoredEvent

### DIFF
--- a/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/AppEngineEventStoreTest.kt
+++ b/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/AppEngineEventStoreTest.kt
@@ -1,15 +1,28 @@
 package com.clouway.kcqrs.adapter.appengine
 
-import com.clouway.kcqrs.core.*
+import com.clouway.kcqrs.core.Aggregate
+import com.clouway.kcqrs.core.AuthoredEvent
+import com.clouway.kcqrs.core.Binary
+import com.clouway.kcqrs.core.EventPayload
+import com.clouway.kcqrs.core.GetEventsResponse
+import com.clouway.kcqrs.core.Identity
+import com.clouway.kcqrs.core.RevertEventsResponse
+import com.clouway.kcqrs.core.SaveEventsResponse
+import com.clouway.kcqrs.core.SaveOptions
 import com.clouway.kcqrs.testing.TestMessageFormat
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper
-import org.hamcrest.CoreMatchers.*
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.hasItems
+import org.hamcrest.CoreMatchers.not
 import org.junit.After
 import org.junit.Assert.assertThat
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.*
 
 /**
@@ -234,7 +247,7 @@ class AppEngineEventStoreTest {
 
     @Test
     fun saveStringWithTooBigSize() {
-        val tooBigStringData  = "aaaaa".repeat(150000)
+        val tooBigStringData = "aaaaa".repeat(150000)
         val result = aggregateBase.saveEvents("Invoice",
                 listOf(EventPayload("::kind::", 1L, "::user 1::", Binary(tooBigStringData)))
         ) as SaveEventsResponse.Success

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AuthoredEvent.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AuthoredEvent.kt
@@ -1,0 +1,13 @@
+package com.clouway.kcqrs.core
+
+/**
+ * AuthoredEvent will be used when you want to have the Identity of
+ * the event provided, e.g. you want the id of the author of the event
+ * and the time of the event.
+ *
+ * @author Vasil Mitov <vasil.mitov@clouway.com>
+ */
+
+abstract class AuthoredEvent private constructor(var identity: Identity?) : Event {
+    constructor() : this(null)
+}

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleMessageBus.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleMessageBus.kt
@@ -63,7 +63,7 @@ class SimpleMessageBus : MessageBus {
 
         handler.handler.handle(command)
     }
-    
+
     override fun handle(event: EventWithPayload) {
         val key = event.event::class.java.name
 

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/AuthoredEventTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/AuthoredEventTest.kt
@@ -1,0 +1,36 @@
+package com.clouway.kcqrs.core
+
+import com.clouway.kcqrs.testing.TestMessageFormat
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+/**
+ * @author Vasil Mitov <vasil.mitov></vasil.mitov>@clouway.com>
+ */
+class AuthoredEventTest {
+
+    @Test
+    fun serializeAndDeserializeAuthoredEvent() {
+        val instant = LocalDateTime.of(2018, 4, 1, 10, 12, 34).toInstant(ZoneOffset.UTC)
+        val anyIdentity = Identity("::user id::", instant)
+
+        val myAuthoredEvent = MyAuthoredEvent("foo")
+        myAuthoredEvent.identity = anyIdentity
+
+
+        val testMessageFormat = TestMessageFormat()
+
+        val format = testMessageFormat.format(myAuthoredEvent)
+        val parsedAuthoredEvent = testMessageFormat.parse<MyAuthoredEvent>(ByteArrayInputStream(format.toByteArray(Charsets.UTF_8)), MyAuthoredEvent::class.java)
+
+        assertThat(parsedAuthoredEvent, `is`(equalTo(myAuthoredEvent)))
+        assertThat(parsedAuthoredEvent.identity, `is`(equalTo(anyIdentity)))
+    }
+}
+
+data class MyAuthoredEvent(val foo: String) : AuthoredEvent()

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleMessageBusTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleMessageBusTest.kt
@@ -1,7 +1,9 @@
 package com.clouway.kcqrs.core
 
 
-import org.hamcrest.CoreMatchers.*
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.nullValue
 import org.junit.Assert.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
@@ -42,6 +44,18 @@ class SimpleMessageBusTest {
         assertThat(firstHandler.lastEvent, `is`(equalTo(event.event)))
         assertThat(secondHandler.lastEvent, `is`(equalTo(event.event)))
 
+    }
+
+    @Test
+    fun handleAuthoredEvent() {
+        val msgBus = SimpleMessageBus()
+        val handler = MyIdentityEventHandler()
+
+        msgBus.registerEventHandler(MyAuthoredEvent::class.java, handler)
+        val event = EventWithPayload(MyAuthoredEvent("foo"), "::payload::")
+
+        msgBus.handle(event)
+        assertThat(handler.lastEvent, `is`(equalTo(event.event)))
     }
 
     @Test
@@ -184,6 +198,16 @@ class SimpleMessageBusTest {
         }
     }
 
+    class MyIdentityEventHandler : EventHandler<MyAuthoredEvent> {
+        var lastEvent: MyAuthoredEvent? = null
+
+        override fun handle(event: MyAuthoredEvent) {
+            lastEvent = event
+        }
+    }
+
     class MyEvent(@JvmField val name: UUID) : Event
+
+    class MyAuthoredEvent(val field: String) : AuthoredEvent()
 
 }


### PR DESCRIPTION
With this PR an AuthoredEvent is added which can be used to have the Identity accessible in the Event when handling it without having to parse that information in the Event fields. 
Note that this is using the Identity provided from the KCQRS library which means that for this to be used the library users need to have this implemented and not using the default identity provider. 
Fixes: #35