### PR TITLE
kcqrs: add the thrown exception in the PublishErrorException

### DIFF
--- a/kcqrs-client-gson/build.gradle
+++ b/kcqrs-client-gson/build.gradle
@@ -31,7 +31,11 @@ dependencies {
   compile 'com.google.code.gson:gson:2.8.0'
   compile 'com.google.http-client:google-http-client:1.23.0'
   compile 'com.google.http-client:google-http-client-gson:1.23.0'
-  
+
+  testCompile project(':kcqrs-testing')
+
+  testCompile 'org.jmock:jmock:2.8.2'
+  testCompile 'org.jmock:jmock-junit4:2.8.2'
   testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/SyncEventPublisherTest.kt
+++ b/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/SyncEventPublisherTest.kt
@@ -1,0 +1,66 @@
+package com.clouway.kcqrs.client
+
+import com.clouway.kcqrs.core.Event
+import com.clouway.kcqrs.core.EventWithPayload
+import com.clouway.kcqrs.core.MessageBus
+import com.clouway.kcqrs.core.PublishErrorException
+import com.clouway.kcqrs.testing.InMemoryMessageBus
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.equalTo
+import org.jmock.AbstractExpectations
+import org.jmock.Expectations
+import org.jmock.integration.junit4.JUnitRuleMockery
+import org.junit.Assert.assertThat
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * @author Vasil Mitov <vasil.mitov></vasil.mitov>@clouway.com>
+ */
+class SyncEventPublisherTest {
+
+    @Rule
+    @JvmField
+    val context = JUnitRuleMockery()
+
+    val mockedMessageBus = context.mock(MessageBus::class.java)
+
+    @Test
+    fun handleEvents() {
+        val messageBus = InMemoryMessageBus()
+        val syncEventPublisher = SyncEventPublisher(messageBus)
+        val firstEvent = EventWithPayload(MyEvent("Foo"), "::payload::")
+        val secondEvent = EventWithPayload(MyEvent("Bar"), "::otherPayload::")
+        syncEventPublisher.publish(listOf(
+                firstEvent,
+                secondEvent
+        ))
+
+        assertThat(messageBus.handledEvents, containsInAnyOrder(firstEvent, secondEvent))
+    }
+
+    @Test
+    fun handlingTheMessageThrowsException() {
+        val syncEventPublisher = SyncEventPublisher(mockedMessageBus)
+        val firstEvent = EventWithPayload(MyEvent("Foo"), "::payload::")
+
+        context.checking(object : Expectations() {
+            init {
+                oneOf(mockedMessageBus).handle(firstEvent)
+                will(AbstractExpectations.throwException(MyException("Some message!")))
+            }
+        })
+        try {
+            syncEventPublisher.publish(listOf(firstEvent))
+            fail("Exception was not thrown")
+        } catch (e: PublishErrorException) {
+            assertThat(e.reason, `is`(equalTo(MyException("Some message!") as Exception)))
+        }
+    }
+}
+
+data class MyException(override val message: String) : Exception(message)
+
+data class MyEvent(val foo: String) : Event

--- a/kcqrs-client/build.gradle
+++ b/kcqrs-client/build.gradle
@@ -30,8 +30,10 @@ dependencies {
   compile 'com.google.http-client:google-http-client:1.23.0'
   compile 'com.google.http-client:google-http-client-gson:1.23.0'
 
-  testCompile project(':kcqrs-testing')
   testCompile 'junit:junit:4.12'
+  testCompile 'org.jmock:jmock:2.8.2'
+  testCompile 'org.jmock:jmock-junit4:2.8.2'
+
   testCompile 'com.google.code.gson:gson:2.8.0'
   testCompile 'org.jmock:jmock:2.8.2'
   testCompile 'org.jmock:jmock-junit4:2.8.2'

--- a/kcqrs-client/src/main/kotlin/com/clouway/kcqrs/client/SyncEventPublisher.kt
+++ b/kcqrs-client/src/main/kotlin/com/clouway/kcqrs/client/SyncEventPublisher.kt
@@ -11,7 +11,7 @@ class SyncEventPublisher(private val messageBus: MessageBus) : EventPublisher {
             try {
                 messageBus.handle(it)
             } catch (ex: Exception) {
-                throw PublishErrorException()
+                throw PublishErrorException(ex)
             }
         }
     }

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/MessageBus.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/MessageBus.kt
@@ -43,7 +43,10 @@ interface MessageBus {
 
     /**
      * Handles event using the registered event handlers.
+     *
+     * @throws Exception different exceptions could be thrown when trying to handle the event.
      */
+    @Throws(Exception::class)
     fun handle(event: EventWithPayload)
 
 }

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/PublishErrorException.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/PublishErrorException.kt
@@ -3,4 +3,4 @@ package com.clouway.kcqrs.core
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-class PublishErrorException : RuntimeException()
+class PublishErrorException(val reason: Exception = Exception()) : RuntimeException()


### PR DESCRIPTION
With this the exception thrown when the SyncEventPublisher handles the events is not transferred via the PublishErrorException. 
Fixes: #32