### PR TITLE
kcqrs: validate aggregate type when getting events by id

### DIFF
--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
@@ -24,15 +24,16 @@ interface EventStore {
      * @param aggregateId the ID of the aggregate which events should be retrieved
      * @return a response of events
      */
-    fun getEvents(aggregateId: String): GetEventsResponse
+    fun getEvents(aggregateId: String, aggregateType: String): GetEventsResponse
 
     /**
      * Retrieves the events that are saved for the stored aggregates.
      *
      * @param aggregateIds a list of IDs of the aggregates which events should be retrieved
+     * @param aggregateType the type of the searched aggregate
      * @return a response of events for each of the requested aggregates
      */
-    fun getEvents(aggregateIds: List<String>): GetEventsResponse
+    fun getEvents(aggregateIds: List<String>, aggregateType: String): GetEventsResponse
 
     /**
      * Reverts last events that are stored for the aggregate.

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/HydrationException.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/HydrationException.kt
@@ -1,6 +1,5 @@
 package com.clouway.kcqrs.core
 
-import java.util.*
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)

--- a/kcqrs-example/build.gradle
+++ b/kcqrs-example/build.gradle
@@ -58,6 +58,8 @@ appengine {
   deploy {   // deploy configuration
     stopPreviousVersion = true  // default - stop the current version
     promote = true              // default - & make this the current version
+    projectId = "kcqrs"
+    version = "1.0"
   }
 
 }


### PR DESCRIPTION
Added the aggregate type to the EventSnapshot in the EventStore so that when aggregates are being loaded by their events there would be a validation if the provided id is for this aggregate type. 

Fixes #38