### PR TITLE
kcqrs/adapters: better serialization support by removing Event requirements

### DIFF
--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AbstractEventHandlerServlet.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AbstractEventHandlerServlet.kt
@@ -1,6 +1,5 @@
 package com.clouway.kcqrs.adapter.appengine
 
-import com.clouway.kcqrs.core.Event
 import com.clouway.kcqrs.core.EventWithPayload
 import com.clouway.kcqrs.core.MessageBus
 import java.io.ByteArrayInputStream
@@ -31,7 +30,7 @@ abstract class AbstractEventHandlerServlet : HttpServlet() {
         }
     }
 
-    abstract fun decode(inputStream: InputStream, type: Class<*>): Event
+    abstract fun decode(inputStream: InputStream, type: Class<*>): Any
 
     abstract fun messageBus(): MessageBus
 

--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
@@ -103,7 +103,7 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
             }
 
             val eventsModel = events.mapIndexed { index, it -> EventModel(it.kind, currentVersion + index + 1, it.identityId, it.timestamp, it.data.payload.toString(Charsets.UTF_8)) }
-            val eventsAsText = eventsModel.map { Text(messageFormat.format(it)) }
+            val eventsAsText = eventsModel.map { Text(messageFormat.formatToString(it)) }
 
             aggregateEvents.addAll(eventsAsText)
 

--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormat.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormat.kt
@@ -4,6 +4,8 @@ import com.clouway.kcqrs.core.messages.MessageFormat
 import com.google.gson.GsonBuilder
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.OutputStreamWriter
 import java.lang.reflect.Type
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -12,6 +14,7 @@ import java.time.LocalDateTime
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 internal class GsonMessageFormat : MessageFormat {
+
     private val gson = GsonBuilder()
             .registerTypeAdapter(LocalDate::class.java, ISOLocalDateAdapter())
             .registerTypeAdapter(LocalDateTime::class.java, ISOLocalDateTimeAdapter())
@@ -21,7 +24,21 @@ internal class GsonMessageFormat : MessageFormat {
         return gson.fromJson<T>(InputStreamReader(stream, Charsets.UTF_8), type)
     }
 
-    override fun format(value: Any): String {
+    override fun formatToString(value: Any): String {
         return gson.toJson(value)
+    }
+
+    override fun formatToBytes(value: Any): ByteArray {
+        return gson.toJson(value).toByteArray(Charsets.UTF_8)
+    }
+
+    override fun writeTo(value: Any, stream: OutputStream) {
+        val writer = OutputStreamWriter(stream)
+        try {
+            gson.toJson(value, writer)
+        } finally {
+            writer.flush()
+        }
+
     }
 }

--- a/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/SyncEventPublisherTest.kt
+++ b/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/SyncEventPublisherTest.kt
@@ -25,7 +25,7 @@ class SyncEventPublisherTest {
     @JvmField
     val context = JUnitRuleMockery()
 
-    val mockedMessageBus = context.mock(MessageBus::class.java)
+    private val mockedMessageBus = context.mock(MessageBus::class.java)
 
     @Test
     fun handleEvents() {

--- a/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/gson/FormatMessagesUsingGsonTest.kt
+++ b/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/gson/FormatMessagesUsingGsonTest.kt
@@ -13,23 +13,22 @@ import java.time.LocalDateTime
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 class FormatMessagesUsingGsonTest {
-    val messageFormat = GsonMessageFormatFactory().createMessageFormat()
+    private val messageFormat = GsonMessageFormatFactory().createMessageFormat()
 
     @Test
     fun parseFormattedMessage() {
 
-        val msg = messageFormat.format(User("Emilia Clark", "Daenerys Targaryen"))
+        val msg = messageFormat.formatToString(User("Emilia Clark", "Daenerys Targaryen"))
 
         val user = messageFormat.parse<User>(ByteArrayInputStream(msg.toByteArray(Charsets.UTF_8)), User::class.java)
         assertThat(user.name, `is`(equalTo("Emilia Clark")))
         assertThat(user.nickname, `is`(equalTo("Daenerys Targaryen")))
     }
 
-
     @Test
     fun encodesLocalDateTimeInISO8601Format() {
-        val jsonPayload = messageFormat.format(DummyLocalDateTime(LocalDateTime.of(2018, 4, 15, 12, 3, 4)))
-        val nullPayload = messageFormat.format(DummyLocalDateTime(null))
+        val jsonPayload = messageFormat.formatToString(DummyLocalDateTime(LocalDateTime.of(2018, 4, 15, 12, 3, 4)))
+        val nullPayload = messageFormat.formatToString(DummyLocalDateTime(null))
         assertThat(jsonPayload, `is`(equalTo("""{"issuedOn":"2018-04-15T12:03:04"}""")))
         assertThat(nullPayload, `is`(equalTo("{}")))
     }
@@ -46,7 +45,7 @@ class FormatMessagesUsingGsonTest {
     
     @Test
     fun using24HourFormat() {
-        val jsonPayload = messageFormat.format(DummyLocalDateTime(LocalDateTime.of(2018, 4, 15, 16, 3, 4)))
+        val jsonPayload = messageFormat.formatToString(DummyLocalDateTime(LocalDateTime.of(2018, 4, 15, 16, 3, 4)))
         assertThat(jsonPayload, `is`(equalTo("""{"issuedOn":"2018-04-15T16:03:04"}""")))
     }
 
@@ -62,8 +61,8 @@ class FormatMessagesUsingGsonTest {
 
     @Test
     fun encodeLocalDateInISO8601Format() {
-        val jsonPayload = messageFormat.format(DummyLocalDate(LocalDate.of(2018, 4, 15)))
-        val nullPayload = messageFormat.format(DummyLocalDate(null))
+        val jsonPayload = messageFormat.formatToString(DummyLocalDate(LocalDate.of(2018, 4, 15)))
+        val nullPayload = messageFormat.formatToString(DummyLocalDate(null))
         assertThat(jsonPayload, `is`(equalTo("""{"issuedOn":"2018-04-15"}""")))
         assertThat(nullPayload, `is`(equalTo("{}")))
     }

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRoot.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRoot.kt
@@ -21,7 +21,7 @@ interface AggregateRoot {
      *
      * @return
      */
-    fun getUncommittedChanges(): List<Event>
+    fun getUncommittedChanges(): List<Any>
 
     /**
      * Mark all changes a committed
@@ -34,7 +34,7 @@ interface AggregateRoot {
      * @param history
      * @throws HydrationException
      */
-    fun loadFromHistory(history: Iterable<Event>)
+    fun loadFromHistory(history: Iterable<Any>)
 
     /**
      * Returns the version of the aggregate when it was hydrated

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRootBase.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRootBase.kt
@@ -13,7 +13,7 @@ import java.util.ArrayList
  */
 abstract class AggregateRootBase private constructor(@JvmField protected var aggregateId: String? = "") : AggregateRoot {
 
-    private var changes: ArrayList<Event> = ArrayList()
+    private var changes: ArrayList<Any> = ArrayList()
     private var version = 0L
 
     constructor() : this(null)
@@ -51,11 +51,11 @@ abstract class AggregateRootBase private constructor(@JvmField protected var agg
         return version
     }
 
-    override fun getUncommittedChanges(): List<Event> {
+    override fun getUncommittedChanges(): List<Any> {
         return if (changes.isEmpty()) listOf() else changes
     }
 
-    override fun loadFromHistory(history: Iterable<Event>) {
+    override fun loadFromHistory(history: Iterable<Any>) {
         for (event in history) {
             applyChange(event, false)
             version++
@@ -68,7 +68,7 @@ abstract class AggregateRootBase private constructor(@JvmField protected var agg
      * @param event
      * @throws HydrationException
      */
-    protected fun applyChange(event: Event) {
+    protected fun applyChange(event: Any) {
         applyChange(event, true)
     }
 
@@ -79,7 +79,7 @@ abstract class AggregateRootBase private constructor(@JvmField protected var agg
      * @param isNew
      * @throws HydrationException
      */
-    private fun applyChange(event: Event, isNew: Boolean) {
+    private fun applyChange(event: Any, isNew: Boolean) {
 
         var method: Method? = null
 

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventHandler.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventHandler.kt
@@ -13,6 +13,6 @@ package com.clouway.kcqrs.core
  * @param <T>
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-interface EventHandler<in T : Event> {
+interface EventHandler<in T> {
     fun handle(event: T)
 }

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventWithPayload.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventWithPayload.kt
@@ -5,4 +5,4 @@ package com.clouway.kcqrs.core
  * part is used as caching of the serialization as different layers are working either with event or
  * with it's payload.
  */
-data class EventWithPayload(val event: Event, val payload: String)
+data class EventWithPayload(val event: Any, val payload: String)

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/MessageBus.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/MessageBus.kt
@@ -65,7 +65,7 @@ interface Interceptor {
 
 }
 
-class SimpleChain(val event: EventWithPayload, private val eventHandlers: List<EventHandler<Event>>) : Interceptor.Chain {
+class SimpleChain(val event: EventWithPayload, private val eventHandlers: List<EventHandler<Any>>) : Interceptor.Chain {
 
     override fun event(): EventWithPayload {
         return event

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
@@ -17,7 +17,7 @@ class SimpleAggregateRepository(private val eventStore: EventStore,
 
         val uncommittedEvents = aggregate.getUncommittedChanges()
 
-        val eventsWithPayload = uncommittedEvents.map { EventWithPayload(it, messageFormat.format(it)) }
+        val eventsWithPayload = uncommittedEvents.map { EventWithPayload(it, messageFormat.formatToString(it)) }
 
         val events = eventsWithPayload.map {
             EventPayload(it.event::class.java.simpleName, identity.time.toEpochMilli(), identity.id, Binary(it.payload))

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleMessageBus.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleMessageBus.kt
@@ -16,7 +16,7 @@ class SimpleMessageBus : MessageBus {
     /**                  `
      * List of event handlers per event
      */
-    private val eventHandlers: MutableMap<String, MutableList<EventHandler<Event>>> = mutableMapOf()
+    private val eventHandlers: MutableMap<String, MutableList<EventHandler<Any>>> = mutableMapOf()
 
     /**
      * List of event interceptors
@@ -40,7 +40,7 @@ class SimpleMessageBus : MessageBus {
         }
 
         @Suppress("UNCHECKED_CAST")
-        eventHandlers[key]!!.add(handler as EventHandler<Event>)
+        eventHandlers[key]!!.add(handler as EventHandler<Any>)
     }
 
     override fun registerInterceptor(interceptor: Interceptor) {

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/messages/MessageFormat.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/messages/MessageFormat.kt
@@ -1,6 +1,8 @@
 package com.clouway.kcqrs.core.messages
 
+import java.io.IOException
 import java.io.InputStream
+import java.io.OutputStream
 import java.lang.reflect.Type
 
 /**
@@ -9,14 +11,24 @@ import java.lang.reflect.Type
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 interface MessageFormat {
-
     /**
      * Parses JSON content from the provided input stream.
      */
     fun <T> parse(stream: InputStream, type: Type): T
 
     /**
-     * Formats the provided value into a JSON object
+     * Formats the provided value into string value.
      */
-    fun format(value: Any): String
+    fun formatToString(value: Any): String
+
+    /**
+     * Formats the provided value into binary value.
+     */
+    fun formatToBytes(value: Any): ByteArray
+
+    /**
+     * Writes the content of passed value to the provided output stream.
+     */
+    @Throws(IOException::class)
+    fun writeTo(value: Any, stream: OutputStream)
 }

--- a/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/KCqrsEventHandler.kt
+++ b/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/KCqrsEventHandler.kt
@@ -13,9 +13,8 @@ import java.io.InputStreamReader
 class KCqrsEventHandler : AbstractEventHandlerServlet() {
     private val gson = Gson()
 
-    override fun decode(inputStream: InputStream, type: Class<*>): Event {
-        val event = gson.fromJson(InputStreamReader(inputStream, "UTF-8"), type)
-        return event as Event
+    override fun decode(inputStream: InputStream, type: Class<*>): Any {
+        return gson.fromJson(InputStreamReader(inputStream, "UTF-8"), type)
     }
 
     override fun messageBus(): MessageBus {

--- a/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/adapter/http/Transports.kt
+++ b/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/adapter/http/Transports.kt
@@ -17,7 +17,7 @@ object Transports {
             if (model == null) {
                 return ""
             }
-            return messageFormat.format(model)
+            return messageFormat.formatToString(model)
         }
     }
 

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryAggregateRepository.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryAggregateRepository.kt
@@ -3,13 +3,12 @@ package com.clouway.kcqrs.testing
 import com.clouway.kcqrs.core.AggregateNotFoundException
 import com.clouway.kcqrs.core.AggregateRepository
 import com.clouway.kcqrs.core.AggregateRoot
-import com.clouway.kcqrs.core.Event
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 class InMemoryAggregateRepository : AggregateRepository {
-    private val aggregateIdToEvents = mutableMapOf<String, MutableList<Event>>()
+    private val aggregateIdToEvents = mutableMapOf<String, MutableList<Any>>()
 
     override fun <T : AggregateRoot> save(aggregate: T) {
         val changes = aggregate.getUncommittedChanges().toMutableList()

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/TestMessageFormat.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/TestMessageFormat.kt
@@ -4,6 +4,8 @@ import com.clouway.kcqrs.core.messages.MessageFormat
 import com.google.gson.Gson
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.OutputStreamWriter
 import java.lang.reflect.Type
 
 /**
@@ -11,12 +13,23 @@ import java.lang.reflect.Type
  */
 
 class TestMessageFormat : MessageFormat {
+
     private val gson = Gson()
     override fun <T> parse(stream: InputStream, type: Type): T {
         return gson.fromJson(InputStreamReader(stream, Charsets.UTF_8), type)
     }
 
-    override fun format(value: Any): String {
+    override fun formatToString(value: Any): String {
         return gson.toJson(value)
+    }
+
+    override fun formatToBytes(value: Any): ByteArray {
+        return gson.toJson(value).toByteArray(Charsets.UTF_8)
+    }
+
+    override fun writeTo(value: Any, stream: OutputStream) {
+        val writer = OutputStreamWriter(stream)
+        gson.toJson(value, writer)
+        writer.close()
     }
 }


### PR DESCRIPTION
The Event class dependency is now removed from AggregateRoot and AggregateRootBase as some of transport adapters cannot be coupled to concrete class (protobuf).