### PR TITLE
kcqrs/adapters: remove Event usage in SimpleAggregateRepository

### DIFF
--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AbstractEventHandlerServlet.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AbstractEventHandlerServlet.kt
@@ -1,9 +1,11 @@
 package com.clouway.kcqrs.adapter.appengine
 
+import com.clouway.kcqrs.core.Binary
 import com.clouway.kcqrs.core.EventWithPayload
 import com.clouway.kcqrs.core.MessageBus
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.util.Base64
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.servlet.http.HttpServlet
@@ -19,11 +21,11 @@ abstract class AbstractEventHandlerServlet : HttpServlet() {
     override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
         val type = req.getParameter("type")
         val payload = req.getParameter("payload")
-        
+        val decodedPayload = Base64.getDecoder().decode(payload)
         val clazz = Class.forName(type)
         try {
-            val event = decode(ByteArrayInputStream(payload.toByteArray(Charsets.UTF_8)), clazz)
-            messageBus().handle(EventWithPayload(event, payload))
+            val event = decode(ByteArrayInputStream(decodedPayload), clazz)
+            messageBus().handle(EventWithPayload(event, Binary(decodedPayload)))
         } catch (ex: Exception) {
             logger.log(Level.SEVERE, "Could not handle the received event", ex)
             resp.setStatus(HttpServletResponse.SC_BAD_REQUEST)

--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/TaskQueueEventPublisher.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/TaskQueueEventPublisher.kt
@@ -5,6 +5,7 @@ import com.clouway.kcqrs.core.EventWithPayload
 import com.google.appengine.api.taskqueue.Queue
 import com.google.appengine.api.taskqueue.QueueFactory
 import com.google.appengine.api.taskqueue.TaskOptions
+import java.util.*
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
@@ -12,11 +13,13 @@ import com.google.appengine.api.taskqueue.TaskOptions
 internal class TaskQueueEventPublisher(private val handlerEndpoint: String,
                                        private val queueName: String? = null) : EventPublisher {
     override fun publish(events: Iterable<EventWithPayload>) {
+
+
         val tasks = events.map {
             TaskOptions.Builder.withUrl(handlerEndpoint)
                     .method(TaskOptions.Method.POST)
                     .param("type", it.event::class.java.name)
-                    .param("payload", it.payload)
+                    .param("payload", Base64.getEncoder().encodeToString(it.payload.payload))
         }
 
         if (tasks.isEmpty()) {

--- a/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/SyncEventPublisherTest.kt
+++ b/kcqrs-client-gson/src/test/kotlin/com/clouway/kcqrs/client/SyncEventPublisherTest.kt
@@ -1,5 +1,6 @@
 package com.clouway.kcqrs.client
 
+import com.clouway.kcqrs.core.Binary
 import com.clouway.kcqrs.core.Event
 import com.clouway.kcqrs.core.EventWithPayload
 import com.clouway.kcqrs.core.MessageBus
@@ -31,8 +32,8 @@ class SyncEventPublisherTest {
     fun handleEvents() {
         val messageBus = InMemoryMessageBus()
         val syncEventPublisher = SyncEventPublisher(messageBus)
-        val firstEvent = EventWithPayload(MyEvent("Foo"), "::payload::")
-        val secondEvent = EventWithPayload(MyEvent("Bar"), "::otherPayload::")
+        val firstEvent = EventWithPayload(MyEvent("Foo"), Binary("::payload::"))
+        val secondEvent = EventWithPayload(MyEvent("Bar"), Binary("::otherPayload::"))
         syncEventPublisher.publish(listOf(
                 firstEvent,
                 secondEvent
@@ -44,7 +45,7 @@ class SyncEventPublisherTest {
     @Test
     fun handlingTheMessageThrowsException() {
         val syncEventPublisher = SyncEventPublisher(mockedMessageBus)
-        val firstEvent = EventWithPayload(MyEvent("Foo"), "::payload::")
+        val firstEvent = EventWithPayload(MyEvent("Foo"), Binary("::payload::"))
 
         context.checking(object : Expectations() {
             init {

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventWithPayload.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventWithPayload.kt
@@ -5,4 +5,4 @@ package com.clouway.kcqrs.core
  * part is used as caching of the serialization as different layers are working either with event or
  * with it's payload.
  */
-data class EventWithPayload(val event: Any, val payload: String)
+data class EventWithPayload(val event: Any, val payload: Binary)

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepositoryTest.kt
@@ -85,7 +85,7 @@ class SimpleAggregateRepositoryTest {
                 listOf(
                         EventWithPayload(
                                 InvoiceCreatedEvent(invoice.getId()!!, "John"),
-                                """{"invoiceId":"${invoice.getId()}","customerName":"John"}"""
+                                Binary("""{"invoiceId":"${invoice.getId()}","customerName":"John"}""")
                         )
                 )
         ))

--- a/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleMessageBusTest.kt
+++ b/kcqrs-core/src/test/kotlin/com/clouway/kcqrs/core/SimpleMessageBusTest.kt
@@ -20,7 +20,7 @@ class SimpleMessageBusTest {
         val handler = MyEventHandler()
         msgBus.registerEventHandler(MyEvent::class.java, handler)
 
-        val event = EventWithPayload(MyEvent(UUID.randomUUID()), "")
+        val event = EventWithPayload(MyEvent(UUID.randomUUID()), Binary(""))
         msgBus.handle(event)
 
         assertThat(handler.lastEvent, `is`(equalTo(event.event)))
@@ -36,7 +36,7 @@ class SimpleMessageBusTest {
         msgBus.registerEventHandler(MyEvent::class.java, firstHandler)
         msgBus.registerEventHandler(MyEvent::class.java, secondHandler)
 
-        val event = EventWithPayload(MyEvent(UUID.randomUUID()), "")
+        val event = EventWithPayload(MyEvent(UUID.randomUUID()), Binary(""))
         msgBus.handle(event)
 
         assertThat(firstHandler.lastEvent, `is`(equalTo(event.event)))
@@ -47,7 +47,7 @@ class SimpleMessageBusTest {
     @Test
     fun noHandlersAreAttached() {
         val msgBus = SimpleMessageBus()
-        msgBus.handle(EventWithPayload(MyEvent(UUID.randomUUID()), ""))
+        msgBus.handle(EventWithPayload(MyEvent(UUID.randomUUID()), Binary("")))
     }
 
     @Test
@@ -124,7 +124,7 @@ class SimpleMessageBusTest {
             }
         })
 
-        val event = EventWithPayload(MyEvent(UUID.randomUUID()), "")
+        val event = EventWithPayload(MyEvent(UUID.randomUUID()), Binary(""))
         msgBus.handle(event)
 
         assertThat(callLog, `is`(equalTo(listOf(
@@ -147,7 +147,7 @@ class SimpleMessageBusTest {
             }
         })
 
-        val event = EventWithPayload(MyEvent(UUID.randomUUID()), "")
+        val event = EventWithPayload(MyEvent(UUID.randomUUID()), Binary(""))
         msgBus.handle(event)
 
         assertThat(callLog, `is`(equalTo(listOf(

--- a/kcqrs-testing/src/test/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBusTest.kt
+++ b/kcqrs-testing/src/test/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBusTest.kt
@@ -1,5 +1,6 @@
 package com.clouway.kcqrs.testing
 
+import com.clouway.kcqrs.core.Binary
 import com.clouway.kcqrs.core.Command
 import com.clouway.kcqrs.core.Event
 import com.clouway.kcqrs.core.EventWithPayload
@@ -25,8 +26,8 @@ class InMemoryMessageBusTest {
     @Test
     fun handleEvents() {
         val messageBus = InMemoryMessageBus()
-        messageBus.handle(EventWithPayload(DummyEvent(), "::payload::"))
-        assertThat(messageBus.handledEvents[0].payload, `is`(equalTo("::payload::")))
+        messageBus.handle(EventWithPayload(DummyEvent(), Binary("::payload::")))
+        assertThat(messageBus.handledEvents[0].payload.payload, `is`(equalTo("::payload::".toByteArray())))
     }
 
     class DummyCommand : Command


### PR DESCRIPTION
The Event usage in SimpleAggregateRepository is now removed by using binary serialization of formats. This change ensures that library is fully capable to be used and in binary formats like protobuf, avro and etc.