### PR TITLE
kcqrs/api: add event information in response objects

### DIFF
--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
@@ -237,7 +237,7 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
         val aggregate = try {
             dataStore.get(aggregateKey)
         } catch (ex: EntityNotFoundException) {
-            return GetEventsResponse.AggregateNotFound
+            return GetEventsResponse.AggregateNotFound(listOf(aggregateId), aggregateType)
         }
 
         @Suppress("UNCHECKED_CAST")
@@ -284,7 +284,7 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
                 val currentVersion = aggregateEntity.getProperty(versionProperty) as Long
 
                 if (count > aggregateEvents.size) {
-                    return RevertEventsResponse.ErrorNotEnoughEventsToRevert
+                    return RevertEventsResponse.ErrorNotEnoughEventsToRevert(aggregateEvents.size, count)
                 }
 
                 val lastEventIndex = aggregateEvents.size - count
@@ -302,7 +302,7 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
                 transaction.commit()
 
             } catch (ex: EntityNotFoundException) {
-                return RevertEventsResponse.AggregateNotFound
+                return RevertEventsResponse.AggregateNotFound(aggregateId, aggregateType)
             }
 
         } catch (ex: Exception) {
@@ -313,7 +313,7 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
             }
         }
 
-        return RevertEventsResponse.Success
+        return RevertEventsResponse.Success(listOf())
     }
 
     private fun aggregateKey(aggregateType: String, aggregateId: String, aggregateIndex: Long) =

--- a/kcqrs-client/src/main/kotlin/com/clouway/kcqrs/client/HttpEventStore.kt
+++ b/kcqrs-client/src/main/kotlin/com/clouway/kcqrs/client/HttpEventStore.kt
@@ -72,7 +72,7 @@ class HttpEventStore(private val endpoint: URL,
             }
 
         } catch (ex: IOException) {
-            return SaveEventsResponse.ErrorInCommunication
+            return SaveEventsResponse.ErrorInCommunication(ex.message!!)
         }
 
         return SaveEventsResponse.Error("Generic Error")
@@ -89,7 +89,7 @@ class HttpEventStore(private val endpoint: URL,
 
             // Aggregate was not found and no events cannot be returned
             if (response.statusCode == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
-                return GetEventsResponse.AggregateNotFound
+                return GetEventsResponse.AggregateNotFound(aggregateIds, aggregateType)
             }
 
             if (response.isSuccessStatusCode) {
@@ -115,7 +115,7 @@ class HttpEventStore(private val endpoint: URL,
             return GetEventsResponse.Error("got unknown error")
 
         } catch (ex: IOException) {
-            return GetEventsResponse.ErrorInCommunication
+            return GetEventsResponse.ErrorInCommunication(ex.message!!)
         }
     }
 
@@ -128,7 +128,7 @@ class HttpEventStore(private val endpoint: URL,
 
             // Aggregate was not found and no events cannot be returned
             if (response.statusCode == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
-                return GetEventsResponse.AggregateNotFound
+                return GetEventsResponse.AggregateNotFound(listOf(aggregateId), aggregateType)
             }
 
             if (response.isSuccessStatusCode) {
@@ -154,7 +154,7 @@ class HttpEventStore(private val endpoint: URL,
             return GetEventsResponse.Error("got unknown error")
 
         } catch (ex: IOException) {
-            return GetEventsResponse.ErrorInCommunication
+            return GetEventsResponse.ErrorInCommunication(ex.message!!)
         }
     }
 
@@ -169,11 +169,11 @@ class HttpEventStore(private val endpoint: URL,
 
             // Aggregate was not found, so no events cannot be returned
             if (response.statusCode == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
-                return RevertEventsResponse.AggregateNotFound
+                return RevertEventsResponse.AggregateNotFound(aggregateId, aggregateType)
             }
 
             if (response.isSuccessStatusCode) {
-                return RevertEventsResponse.Success
+                return RevertEventsResponse.Success(listOf())
             }
 
             return RevertEventsResponse.Error("Generic Error")

--- a/kcqrs-client/src/test/kotlin/HttpEventStoreTest.kt
+++ b/kcqrs-client/src/test/kotlin/HttpEventStoreTest.kt
@@ -130,7 +130,7 @@ class HttpEventStoreTest {
                 listOf(EventPayload("::kind::", 1L, "::user id::", Binary("::event data::"))),
                 SaveOptions(aggregateId)) as SaveEventsResponse.ErrorInCommunication
 
-        assertThat(response, `is`(Matchers.equalTo(SaveEventsResponse.ErrorInCommunication)))
+        assertThat(response, `is`(Matchers.equalTo(SaveEventsResponse.ErrorInCommunication("unable to connect"))))
     }
 
     @Test

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
@@ -73,7 +73,7 @@ sealed class SaveEventsResponse {
     /**
      * Returned when there is an communication error
      */
-    object ErrorInCommunication : SaveEventsResponse()
+    data class ErrorInCommunication(val message: String) : SaveEventsResponse()
 
     /**
      * Returned when aggregate's current Events persistence limit has been reached.
@@ -86,26 +86,25 @@ sealed class GetEventsResponse {
 
     data class Success(val aggregates: List<Aggregate>) : GetEventsResponse()
 
-    object SnapshotNotFound : GetEventsResponse()
+    data class SnapshotNotFound(val aggregateId: String, val aggregateType: String) : GetEventsResponse()
 
-    object AggregateNotFound : GetEventsResponse()
+    data class AggregateNotFound(val aggregateIds: List<String>, val aggregateType: String) : GetEventsResponse()
 
     data class Error(val message: String) : GetEventsResponse()
-
     /**
      * Returned when there is an communication error
      */
-    object ErrorInCommunication : GetEventsResponse()
+    data class ErrorInCommunication(val message: String) : GetEventsResponse()
 
 }
 
 sealed class RevertEventsResponse {
 
-    object Success : RevertEventsResponse()
+    data class Success(val eventIds: List<String>) : RevertEventsResponse()
 
-    object AggregateNotFound : RevertEventsResponse()
+    data class AggregateNotFound(val aggregateId: String, val aggregateType: String) : RevertEventsResponse()
 
-    object ErrorNotEnoughEventsToRevert : RevertEventsResponse()
+    data class ErrorNotEnoughEventsToRevert(val available: Int, val requested: Int) : RevertEventsResponse()
 
     data class Error(val message: String) : RevertEventsResponse()
 }

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryEventStore.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryEventStore.kt
@@ -49,7 +49,7 @@ class InMemoryEventStore(private val eventsLimit: Int) : EventStore {
     override fun getEvents(aggregateId: String, aggregateType: String): GetEventsResponse {
         val key = aggregateKey(aggregateType, aggregateId)
         if (!idToAggregate.containsKey(key)) {
-            return GetEventsResponse.AggregateNotFound
+            return GetEventsResponse.AggregateNotFound(listOf(aggregateId), aggregateType)
         }
 
         val aggregate = idToAggregate[key]!!
@@ -85,7 +85,7 @@ class InMemoryEventStore(private val eventsLimit: Int) : EventStore {
 
         idToAggregate[aggregateKey(aggregateType, aggregateId)] = StoredAggregate(aggregate.aggregateId, aggregate.aggregateType, updatedEvents, aggregate.snapshot)
 
-        return RevertEventsResponse.Success
+        return RevertEventsResponse.Success(listOf())
     }
 
     fun pretendThatNextSaveWillReturn(response: SaveEventsResponse) {


### PR DESCRIPTION
Most of the response objects are now containing and metadata for the operation which was completede successfull or un-successfull.