### PR TITLE
kcqrs-api: read all events for specific aggregates

### DIFF
--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
@@ -130,7 +130,7 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
                 val sequenceId = sequenceIds[index]
                 val eventIndex = Entity(indexKind, eventModel.version, aggregateKey)
                 eventIndex.setUnindexedProperty(aggregateIdProperty, aggregateId)
-                eventIndex.setUnindexedProperty(aggregateTypeProperty, aggregateType)
+                eventIndex.setIndexedProperty(aggregateTypeProperty, aggregateType)
                 eventIndex.setUnindexedProperty(aggregateIndexProperty, aggregateIndex)
                 eventIndex.setUnindexedProperty(versionProperty, eventModel.version)
                 eventIndex.setIndexedProperty(sequenceProperty, sequenceId)
@@ -291,7 +291,16 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
             Query.FilterPredicate(sequenceProperty, Query.FilterOperator.LESS_THAN, startSequenceId)
         }
 
-        var eventKeys = dataStore.prepare(Query(indexKind).setFilter(eventsFilterPredicate))
+        var filter: Query.Filter = eventsFilterPredicate
+
+
+        if (!request.aggregateTypes.isEmpty()) {
+            filter = Query.CompositeFilter(Query.CompositeFilterOperator.AND, listOf(
+                    eventsFilterPredicate, Query.FilterPredicate(aggregateTypeProperty, Query.FilterOperator.IN, request.aggregateTypes)
+            ))
+        }
+        
+        var eventKeys = dataStore.prepare(Query(indexKind).setFilter(filter))
                 .asIterable(FetchOptions.Builder.withLimit(request.maxCount))
                 .map {
                     val aggregateType = it.getProperty(aggregateTypeProperty) as String

--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineKcqrs.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineKcqrs.kt
@@ -35,7 +35,8 @@ class AppEngineKcqrs private constructor(private val messageBus: MessageBus,
         var kcqrsHandlerEndpoint = "/worker/kcqrs"
         var queueName: String? = null
         var identityProvider: IdentityProvider = IdentityProvider.Default()
-        var eventStore = AppEngineEventStore(kind, messageFormatFactory.createMessageFormat(), IdGenerators.snowflake())
+        var idGenerator: IdGenerator = IdGenerators.snowflake()
+        var eventStore = AppEngineEventStore(kind, messageFormatFactory.createMessageFormat(), idGenerator)
         var eventPublisher: EventPublisher = TaskQueueEventPublisher(kcqrsHandlerEndpoint, queueName)
 
         fun build(init: Builder.() -> Unit): Kcqrs {

--- a/kcqrs-client/src/main/kotlin/com/clouway/kcqrs/client/HttpEventStore.kt
+++ b/kcqrs-client/src/main/kotlin/com/clouway/kcqrs/client/HttpEventStore.kt
@@ -165,8 +165,13 @@ class HttpEventStore(private val endpoint: URL,
 
     override fun getAllEvents(request: GetAllEventsRequest): GetAllEventsResponse {
         val all = URLEncoder.encode("\$all", "UTF-8")
+
+        val aggregateTypes = request.aggregateTypes.joinToString(separator = ",")
+
+        val aggregateTypesParam = if (aggregateTypes.isNotEmpty()) "&aggregateTypes=$aggregateTypes" else ""
+
         val url = endpoint.toString() + "/v2/aggregates/$all?fromPosition=${request.position?.value
-                        ?: 0}&maxCount=${request.maxCount}&readDirection=${request.readDirection.name}"
+                        ?: 0}&maxCount=${request.maxCount}&readDirection=${request.readDirection.name}$aggregateTypesParam"
         val req = requestFactory.buildGetRequest(GenericUrl(url))
                 .setConnectTimeout(timeout).setReadTimeout(timeout)
         req.throwExceptionOnExecuteError = false

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
@@ -87,9 +87,12 @@ sealed class SaveEventsResponse {
     data class SnapshotRequired(val currentEvents: List<EventPayload>, val currentSnapshot: Snapshot? = null) : SaveEventsResponse()
 }
 
-
-
-data class GetAllEventsRequest(val position: Position?, val maxCount: Int, val readDirection: ReadDirection = ReadDirection.FORWARD)
+data class GetAllEventsRequest(
+        val position: Position? = Position(0),
+        val maxCount: Int = 100,
+        val readDirection: ReadDirection = ReadDirection.FORWARD,
+        val aggregateTypes: List<String> = listOf()
+)
 
 sealed class GetAllEventsResponse {
     data class Success(val events:List<IndexedEvent>, val readDirection: ReadDirection, val nextPosition: Position?) : GetAllEventsResponse()

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/IdGenerators.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/IdGenerators.kt
@@ -24,7 +24,7 @@ object IdGenerators {
         // are created
         if (nodeId != null) {
             // Make sure that nodeId not exceeds it's size
-            return SnowflakeIdGenerator(nodeId.hashCode() % 1024,epoch)
+            return SnowflakeIdGenerator(Math.abs(nodeId.hashCode() % 1023), epoch)
         }
         
         return SnowflakeIdGenerator()


### PR DESCRIPTION
The user is now able to specify a list of aggregates for which events to be retrieved in the request.