### PR TITLE
kcqrs: fixing the versioning of aggregates with snapshots

### DIFF
--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
@@ -2,18 +2,7 @@ package com.clouway.kcqrs.adapter.appengine
 
 import com.clouway.kcqrs.core.*
 import com.clouway.kcqrs.core.messages.MessageFormat
-import com.google.appengine.api.datastore.Blob
-import com.google.appengine.api.datastore.DatastoreServiceFactory
-import com.google.appengine.api.datastore.Entity
-import com.google.appengine.api.datastore.EntityNotFoundException
-import com.google.appengine.api.datastore.EntityTranslator
-import com.google.appengine.api.datastore.FetchOptions
-import com.google.appengine.api.datastore.Key
-import com.google.appengine.api.datastore.KeyFactory
-import com.google.appengine.api.datastore.Query
-import com.google.appengine.api.datastore.Text
-import com.google.appengine.api.datastore.Transaction
-import com.google.appengine.api.datastore.TransactionOptions
+import com.google.appengine.api.datastore.*
 import java.io.ByteArrayInputStream
 
 /**
@@ -104,7 +93,7 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
             } catch (ex: EntityNotFoundException) {
                 val entity = Entity(aggregateKey)
                 entity.setUnindexedProperty(eventsProperty, mutableListOf<String>())
-                entity.setUnindexedProperty(versionProperty, 0L)
+                entity.setUnindexedProperty(versionProperty, saveOptions.createSnapshot.snapshot?.version ?: 0L)
                 entity.setProperty(aggregateTypeProperty, aggregateType)
 
                 entity

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/EventStore.kt
@@ -1,6 +1,7 @@
 package com.clouway.kcqrs.core
 
-import java.util.*
+import java.util.Arrays
+import java.util.UUID
 
 /**
  * EventStore is an abstraction of the persistence layer of the EventStore.

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/SimpleAggregateRepository.kt
@@ -53,7 +53,7 @@ class SimpleAggregateRepository(private val eventStore: EventStore,
                 val createSnapshotResponse = eventStore.saveEvents(
                         aggregateClass.simpleName,
                         events,
-                        SaveOptions(aggregate.getId()!!, 0, configuration.topicName(aggregate), CreateSnapshot(true, newSnapshot)))
+                        SaveOptions(aggregate.getId()!!, newSnapshot.version, configuration.topicName(aggregate), CreateSnapshot(true, newSnapshot)))
 
                 when (createSnapshotResponse) {
                     is SaveEventsResponse.Success -> {


### PR DESCRIPTION
The versioning of the aggregates with snapshots was incorrect. When a snapshot was created, then the version in the events starts from 0 again. Now the client passes the last version of the aggregate in the new AggregateEntity.