### PR TITLE
kcqrs: simplify the aggregate to snapshot transformations

### DIFF
--- a/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormat.kt
+++ b/kcqrs-client-gson/src/main/kotlin/com/clouway/kcqrs/client/gson/GsonMessageFormat.kt
@@ -24,6 +24,10 @@ internal class GsonMessageFormat : MessageFormat {
         return gson.fromJson<T>(InputStreamReader(stream, Charsets.UTF_8), type)
     }
 
+    override fun <T> parse(json: String, type: Class<T>): T {
+        return gson.fromJson<T>(json, type)
+    }
+
     override fun formatToString(value: Any): String {
         return gson.toJson(value)
     }

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRoot.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRoot.kt
@@ -41,29 +41,5 @@ interface AggregateRoot {
      * @return
      */
     fun getExpectedVersion(): Long
-
-    /**
-     * Returns a SnapshotMapper that will be used in creation
-     * of Snapshots for the EventStore
-     */
-    fun getSnapshotMapper(): SnapshotMapper<AggregateRoot>
-
-    /**
-     * Builds an aggregate from snapshot data and the current version of the snapshot
-     */
-    fun <T : AggregateRoot> fromSnapshot(snapshotData: String, snapshotVersion: Long): T
 }
 
-
-interface SnapshotMapper<T : AggregateRoot> {
-
-    /**
-     * Serializes the current entity to a string snapshot
-     */
-    fun toSnapshot(data: T): Snapshot
-
-    /**
-     * Create an aggregate from given snapshot
-     */
-    fun fromSnapshot(snapshot: String, snapshotVersion: Long): T
-}

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/messages/MessageFormat.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/messages/MessageFormat.kt
@@ -15,6 +15,10 @@ interface MessageFormat {
      * Parses JSON content from the provided input stream.
      */
     fun <T> parse(stream: InputStream, type: Type): T
+    /**
+     * Parses JSON content from the provided input stream.
+     */
+    fun <T> parse(json: String, type: Class<T>): T
 
     /**
      * Formats the provided value into string value.

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/TestMessageFormat.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/TestMessageFormat.kt
@@ -14,6 +14,10 @@ import java.lang.reflect.Type
 
 class TestMessageFormat : MessageFormat {
 
+    override fun <T> parse(json: String, type: Class<T>): T {
+        return gson.fromJson<T>(json, type)
+    }
+
     private val gson = Gson()
     override fun <T> parse(stream: InputStream, type: Type): T {
         return gson.fromJson(InputStreamReader(stream, Charsets.UTF_8), type)


### PR DESCRIPTION
Useless interfaces were deleted. The code were simplified.
Type adapters for the LocalDate and LocalDateTime were applied to the
snapshot output json, that will be stored in the datastore