### PR TITLE
kcqrs-appengine: retrieve correct agg version from current snapshot entity

### DIFF
--- a/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
+++ b/kcqrs-appengine/src/main/kotlin/com/clouway/kcqrs/adapter/appengine/AppEngineEventStore.kt
@@ -142,7 +142,7 @@ class AppEngineEventStore(private val kind: String = "Event", private val messag
                 if (snapshotEntity != null) {
                     val blobData = snapshotEntity.getProperty("data") as Blob
                     snapshot = Snapshot(
-                            snapshotEntity.getProperty("aggregateIndex") as Long? ?: 0,
+                            snapshotEntity.getProperty("version") as Long? ?: 0,
                             Binary(blobData.bytes))
                 }
                 aggregateEvents.removeAll(eventsAsText)

--- a/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/AppEngineEventStoreTest.kt
+++ b/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/AppEngineEventStoreTest.kt
@@ -464,15 +464,20 @@ class AppEngineEventStoreTest {
     @Test
     fun onEventLimitReachSnapshotIsReturned() {
         aggregateBase.saveEvents("Invoice",
+            listOf(EventPayload("::kind::", 1L, "::user 1::", Binary("::data0::"))),
+            SaveOptions("::aggregateId::", 0, "::topic::", CreateSnapshot(true, Snapshot(0, Binary("::snapshotData::"))))
+        )
+
+        aggregateBase.saveEvents("Invoice",
                 listOf(EventPayload("::kind::", 1L, "::user 1::", Binary("::data::"))),
-                SaveOptions("::aggregateId::", 0, "::topic::", CreateSnapshot(true, Snapshot(0, Binary("::snapshotData::"))))
+                SaveOptions("::aggregateId::", 1, "::topic::", CreateSnapshot(true, Snapshot(1, Binary("::snapshotData::"))))
         )
 
         val tooBigStringData = "aaaaaaaa".repeat(150000)
 
         val eventLimitReachedResponse = aggregateBase.saveEvents("Invoice",
                 listOf(EventPayload("::kind::", 1L, "::user 1::", Binary(tooBigStringData))),
-                SaveOptions("::aggregateId::", 1)
+                SaveOptions("::aggregateId::", 2)
         ) as SaveEventsResponse.SnapshotRequired
 
         assertThat(eventLimitReachedResponse.currentEvents, `is`(equalTo(listOf(EventPayload("::kind::", 1L, "::user 1::", Binary("::data::"))))))

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRootBase.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/AggregateRootBase.kt
@@ -21,7 +21,7 @@ abstract class AggregateRootBase private constructor(@JvmField protected var agg
         return aggregateId
     }
 
-    override fun <T : AggregateRoot> fromSnapshot(snapshotData: String, snapshotVersion: Long): T {
+    final override fun <T : AggregateRoot> fromSnapshot(snapshotData: String, snapshotVersion: Long): T {
         val snapshotRootBase = getSnapshotMapper().fromSnapshot(snapshotData, snapshotVersion)
         val newInstance = this@AggregateRootBase::class.java.newInstance()
         setFields(snapshotRootBase, newInstance)
@@ -38,9 +38,7 @@ abstract class AggregateRootBase private constructor(@JvmField protected var agg
             }
 
             override fun fromSnapshot(snapshot: String, snapshotVersion: Long): AggregateRoot {
-                val agg = gson.fromJson(snapshot, this@AggregateRootBase::class.java)
-                agg.version = agg.version + snapshotVersion
-                return agg
+                return gson.fromJson(snapshot, this@AggregateRootBase::class.java)
             }
         }
     }


### PR DESCRIPTION
Fix wrong property name instead "aggregateIndex" now is used "version"