### PR TITLE
kcqrs: command handlers return response

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=v0.0.6-SNAPSHOT
+version=v1.0.0-SNAPSHOT

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/Command.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/Command.kt
@@ -6,4 +6,4 @@ package com.clouway.kcqrs.core
  * 
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-interface Command
+interface Command<V>

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/CommandHandler.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/CommandHandler.kt
@@ -3,7 +3,7 @@ package com.clouway.kcqrs.core
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-interface CommandHandler<in T : Command> {
+interface CommandHandler<in T : Command<V>, V> {
 
     /**
      * Handle the command
@@ -14,5 +14,5 @@ interface CommandHandler<in T : Command> {
      * @throws AggregateNotFoundException
      */
     @Throws(EventCollisionException::class, HydrationException::class, AggregateNotFoundException::class)
-    fun handle(command: T)
+    fun handle(command: T): V
 }

--- a/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/MessageBus.kt
+++ b/kcqrs-core/src/main/kotlin/com/clouway/kcqrs/core/MessageBus.kt
@@ -15,7 +15,7 @@ interface MessageBus {
      * @param aClass
      * @param handler
      */
-    fun <T : Command> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T>, validation: Validation<T> = Validation {})
+    fun <T : Command<R>, R> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T, R>, validation: Validation<T> = Validation {})
 
     /**
      * Register an event handler
@@ -39,7 +39,7 @@ interface MessageBus {
      * @throws AggregateNotFoundException
      */
     @Throws(EventCollisionException::class, HydrationException::class, AggregateNotFoundException::class)
-    fun <T : Command> send(command: T)
+    fun <T : Command<R>, R> send(command: T): R
 
     /**
      * Handles event using the registered event handlers.

--- a/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/commands/RegisterProductCommand.kt
+++ b/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/commands/RegisterProductCommand.kt
@@ -1,9 +1,9 @@
 package com.clouway.kcqrs.example.commands
 
 import com.clouway.kcqrs.core.Command
-import java.util.*
+import java.util.UUID
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
-data class RegisterProductCommand(val id: UUID, val name: String) : Command
+data class RegisterProductCommand(val id: UUID, val name: String) : Command<String>

--- a/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/commands/RegisterProductCommandHandler.kt
+++ b/kcqrs-example/src/main/kotlin/com/clouway/kcqrs/example/commands/RegisterProductCommandHandler.kt
@@ -1,14 +1,14 @@
 package com.clouway.kcqrs.example.commands
 
 import com.clouway.kcqrs.core.AggregateNotFoundException
-import com.clouway.kcqrs.core.CommandHandler
 import com.clouway.kcqrs.core.AggregateRepository
+import com.clouway.kcqrs.core.CommandHandler
 import com.clouway.kcqrs.example.domain.Product
 
 
-class RegisterProductCommandHandler(private val eventRepository: AggregateRepository) : CommandHandler<RegisterProductCommand> {
+class RegisterProductCommandHandler(private val eventRepository: AggregateRepository) : CommandHandler<RegisterProductCommand, String> {
 
-    override fun handle(command: RegisterProductCommand) {
+    override fun handle(command: RegisterProductCommand): String {
         val id = command.id.toString()
         try {
             eventRepository.getById(id, Product::class.java)
@@ -18,6 +18,7 @@ class RegisterProductCommandHandler(private val eventRepository: AggregateReposi
             val product = Product(id, command.name)
             eventRepository.save(product)
         }
+        return "OK"
     }
 
 }

--- a/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBus.kt
+++ b/kcqrs-testing/src/main/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBus.kt
@@ -1,19 +1,36 @@
 package com.clouway.kcqrs.testing
 
-import com.clouway.kcqrs.core.*
+import com.clouway.kcqrs.core.Command
+import com.clouway.kcqrs.core.CommandHandler
+import com.clouway.kcqrs.core.Event
+import com.clouway.kcqrs.core.EventHandler
+import com.clouway.kcqrs.core.EventWithPayload
+import com.clouway.kcqrs.core.Interceptor
+import com.clouway.kcqrs.core.MessageBus
+import com.clouway.kcqrs.core.ValidatedCommandHandler
+import com.clouway.kcqrs.core.Validation
 
 /**
  * @author Miroslav Genov (miroslav.genov@clouway.com)
  */
 class InMemoryMessageBus() : MessageBus {
     val handledEvents = mutableListOf<EventWithPayload>()
-    val sentCommands = mutableListOf<Command>()
-    
+    val sentCommands = mutableListOf<Command<Any>>()
+
+
+    private val commandHandlers: MutableMap<String, ValidatedCommandHandler<Command<Any>, Any>> = mutableMapOf()
+
+
     override fun handle(event: EventWithPayload) {
         handledEvents.add(event)
     }
 
-    override fun <T : Command> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T>, validation: Validation<T>) {
+    override fun <T : Command<V>, V> registerCommandHandler(aClass: Class<T>, handler: CommandHandler<T, V>, validation: Validation<T>) {
+        val key = aClass.name
+
+        val commandHandler = ValidatedCommandHandler(handler, validation)
+        @Suppress("UNCHECKED_CAST")
+        commandHandlers[key] = commandHandler as ValidatedCommandHandler<Command<Any>, Any>
 
     }
 
@@ -21,12 +38,23 @@ class InMemoryMessageBus() : MessageBus {
 
     }
 
-    override fun <T : Command> send(command: T) {
-        sentCommands.add(command)
+
+    override fun <T : Command<V>, V> send(command: T): V {
+        sentCommands.add(command as Command<Any>)
+
+        val key = command::class.java.name
+
+        if (!commandHandlers.containsKey(key)) {
+            throw IllegalArgumentException("No proper handler found!")
+        }
+
+        val handler = commandHandlers[key] as ValidatedCommandHandler<T, V>
+
+        return handler.handler.handle(command)
+
     }
 
     override fun registerInterceptor(interceptor: Interceptor) {
 
     }
-
 }

--- a/kcqrs-testing/src/test/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBusTest.kt
+++ b/kcqrs-testing/src/test/kotlin/com/clouway/kcqrs/testing/InMemoryMessageBusTest.kt
@@ -2,6 +2,7 @@ package com.clouway.kcqrs.testing
 
 import com.clouway.kcqrs.core.Binary
 import com.clouway.kcqrs.core.Command
+import com.clouway.kcqrs.core.CommandHandler
 import com.clouway.kcqrs.core.Event
 import com.clouway.kcqrs.core.EventWithPayload
 import org.hamcrest.CoreMatchers.`is`
@@ -14,13 +15,21 @@ import org.junit.Test
  */
 class InMemoryMessageBusTest {
 
+    @Test(expected = IllegalArgumentException::class)
+    fun handleCommandsWithNoHandler() {
+        val messageBus = InMemoryMessageBus()
+        val command = DummyCommand()
+        messageBus.send(command)
+    }
+
     @Test
     fun handleCommands() {
         val messageBus = InMemoryMessageBus()
         val command = DummyCommand()
+        messageBus.registerCommandHandler(DummyCommand::class.java, DummyCommandHandler())
         messageBus.send(command)
 
-        assertThat(messageBus.sentCommands[0], `is`(equalTo(command as Command)))
+        assertThat(messageBus.sentCommands[0], `is`(equalTo(command as Command<Any>)))
     }
 
     @Test
@@ -30,6 +39,9 @@ class InMemoryMessageBusTest {
         assertThat(messageBus.handledEvents[0].payload.payload, `is`(equalTo("::payload::".toByteArray())))
     }
 
-    class DummyCommand : Command
+    class DummyCommand : Command<String>
     class DummyEvent : Event
+    class DummyCommandHandler : CommandHandler<DummyCommand, String> {
+        override fun handle(command: DummyCommand) = "OK"
+    }
 }


### PR DESCRIPTION
Sometimes, the command handlers should return response, such a
situations are when the http CRUD handlers requires a result to be
return to the client. This result usually contains the data of the view,
with some calculations and logic that were applied over it in the
aggregate