### PR TITLE
adapter/gae: add check for null of events property

### DIFF
--- a/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/AppEngineEventStoreTest.kt
+++ b/kcqrs-appengine/src/test/java/com/clouway/kcqrs/adapter/appengine/AppEngineEventStoreTest.kt
@@ -213,6 +213,21 @@ class AppEngineEventStoreTest {
     fun revertZeroEventsIsNotAllowed() {
         aggregateBase.revertLastEvents("Task", "::any id::", 0)
     }
+    
+    @Test
+    fun getEventAfterRevert() {
+        val events = listOf(
+            EventPayload("::kind 1::", 1L, "::user1::", Binary("data0")),
+            EventPayload("::kind 2::", 2L, "::user1::", Binary("data0")),
+            EventPayload("::kind 2::", 3L, "::user1::", Binary("data0")),
+            EventPayload("::kind 2::", 4L, "::user1::", Binary("data0"))
+        )
+        
+        aggregateBase.saveEvents("Task", events, saveOptions = SaveOptions(aggregateId = "QnogQXP2kNo", version = 0))
+        
+        val rr = aggregateBase.revertLastEvents("Task", "QnogQXP2kNo", events.size)
+        aggregateBase.getEvents("Task", "::any id::") as GetEventsResponse.AggregateNotFound
+    }
 
     @Test
     fun revertingMoreThenTheAvailableEvents() {

--- a/kcqrs-client-gson/build.gradle
+++ b/kcqrs-client-gson/build.gradle
@@ -3,7 +3,7 @@ group 'com.clouway.kcqrs'
 description = 'kcqrs-core'
 
 buildscript {
-  ext.kotlin_version = '1.2.30'
+  ext.kotlin_version = '1.3.71'
 
   repositories {
     mavenCentral()

--- a/kcqrs-client/build.gradle
+++ b/kcqrs-client/build.gradle
@@ -3,7 +3,7 @@ group 'com.clouway.kcqrs'
 description = 'kcqrs-client'
 
 buildscript {
-  ext.kotlin_version = '1.2.30'
+  ext.kotlin_version = '1.3.71'
 
   repositories {
     mavenCentral()

--- a/kcqrs-core/build.gradle
+++ b/kcqrs-core/build.gradle
@@ -3,7 +3,7 @@ group 'com.clouway.kcqrs'
 description = 'kcqrs-core'
 
 buildscript {
-  ext.kotlin_version = '1.2.30'
+  ext.kotlin_version = '1.3.71'
 
   repositories {
     mavenCentral()

--- a/kcqrs-example/build.gradle
+++ b/kcqrs-example/build.gradle
@@ -1,7 +1,7 @@
 group 'com.clouway.kcqrs.example'
 
 buildscript {
-  ext.kotlin_version = '1.2.30'
+  ext.kotlin_version = '1.3.71'
   ext.gae_version = '1.9.56'
 
   repositories {

--- a/kcqrs-testing/build.gradle
+++ b/kcqrs-testing/build.gradle
@@ -1,7 +1,7 @@
 group 'com.clouway.kcqrs'
 
 buildscript {
-  ext.kotlin_version = '1.2.30'
+  ext.kotlin_version = '1.3.71'
   ext.gae_version = '1.9.56'
 
   repositories {


### PR DESCRIPTION
Added check for null of events property as in some situations JVM implementation of the datastore could represent empty list as a nullable field.

As a side change, the kotlin version is updated.